### PR TITLE
Bump patch version for Symbolics v7 compat bump

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicAnalysis"
 uuid = "4297ee4d-0239-47d8-ba5d-195ecdf594fe"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com>", "Shashi Gowda <gowda@mit.edu>"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

@ChrisRackauckas the compat bump for Symbolics to 7.25 was merged to main but never registered. Can we get a release? This being stuck on v6 is preventing some of the OptimizationBase tests from running. 