### PR TITLE
Bump version to 0.3.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicAnalysis"
 uuid = "4297ee4d-0239-47d8-ba5d-195ecdf594fe"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com>", "Shashi Gowda <gowda@mit.edu>"]
-version = "0.3.7"
+version = "0.3.8"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"


### PR DESCRIPTION
Automated patch version bump (0.3.7 -> 0.3.8) to release unreleased commits on `main` via JuliaRegistrator.