### PR TITLE
Fix DCP composition rule: affine atoms, monotonicity tuples, norm p<1

### DIFF
--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -154,21 +154,29 @@ add_dcprule(maximum, array_domain(RealLine()), AnySign, Convex, Increasing)
 
 add_dcprule(minimum, array_domain(RealLine()), AnySign, Concave, Increasing)
 
-#incorrect for p<1
-add_dcprule(
-    norm,
-    (array_domain(RealLine()), Interval{:closed, :open}(1, Inf)),
-    Positive,
-    Convex,
-    increasing_if_positive
-)
-add_dcprule(
-    norm,
-    (array_domain(RealLine()), Interval{:closed, :open}(0, 1)),
-    Positive,
-    Convex,
-    increasing_if_positive
-)
+# `norm(x, p)` is only a norm (hence convex) for p >= 1. For 0 < p < 1 the
+# generalized "norm" (sum |x_i|^p)^(1/p) is concave on the nonnegative orthant
+# and has no DCP curvature for sign-unknown arguments; for p <= 0 it is not
+# DCP-representable. The rule depends on the value of `p`, so it is a
+# specialized `dcprule` method like `^` rather than a static table entry.
+function dcprule(::typeof(norm), x, p)
+    pv = constval(p)
+    args = (x, p)
+    if !(pv isa Number)
+        return makerule(array_domain(RealLine()), Positive, UnknownCurvature, AnyMono), args
+    elseif pv >= 1
+        return makerule(array_domain(RealLine()), Positive, Convex, increasing_if_positive), args
+    elseif pv > 0
+        curv = getsign(x) == Positive ? Concave : UnknownCurvature
+        return makerule(array_domain(HalfLine()), Positive, curv, Increasing), args
+    else
+        return makerule(array_domain(RealLine()), Positive, UnknownCurvature, AnyMono), args
+    end
+end
+function dcprule(::typeof(norm), x)
+    return makerule(array_domain(RealLine()), Positive, Convex, increasing_if_positive), (x,)
+end
+hasdcprule(::typeof(norm)) = true
 
 """
     perspective(f::Function, x, s::Real)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -96,21 +96,20 @@ function dcprule(f, args...)
     end
 
     if dcprules_dict[f] isa Vector
-        for i in 1:length(dcprules_dict[f])
-            if (dcprules_dict[f][i].domain isa Domain) &&
-                    all(issubset.(argsdomain, Ref(dcprules_dict[f][i].domain)))
-                return dcprules_dict[f][i], args
-            elseif !(dcprules_dict[f][i].domain isa Domain) &&
-                    all(issubset.(argsdomain, dcprules_dict[f][i].domain))
-                return dcprules_dict[f][i], args
-            else
-                throw(
-                    ArgumentError(
-                        "No DCP rule found for $f with arguments $args with domain $argsdomain",
-                    ),
-                )
+        for rule in dcprules_dict[f]
+            if (rule.domain isa Domain) &&
+                    all(issubset.(argsdomain, Ref(rule.domain)))
+                return rule, args
+            elseif !(rule.domain isa Domain) &&
+                    all(issubset.(argsdomain, rule.domain))
+                return rule, args
             end
         end
+        throw(
+            ArgumentError(
+                "No DCP rule found for $f with arguments $args with domain $argsdomain",
+            ),
+        )
     elseif (dcprules_dict[f].domain isa Domain) &&
             all(issubset.(argsdomain, Ref(dcprules_dict[f].domain)))
         return dcprules_dict[f], args
@@ -327,11 +326,34 @@ function get_arg_property(monotonicity, i, args)
     @label start
     return if monotonicity isa Function
         monotonicity(args[i])
-    elseif monotonicity isa Tuple && i <= length(monotonicity)
-        monotonicity = monotonicity[i]
+    elseif monotonicity isa Tuple
+        # A rule may declare fewer monotonicities than the call has arguments —
+        # in particular `add_dcprule` wraps a scalar monotonicity into a
+        # single-entry tuple that applies to every argument — so the last
+        # declared entry covers the remaining arguments.
+        monotonicity = monotonicity[min(i, length(monotonicity))]
         @goto start
     else
         monotonicity
+    end
+end
+
+# The DCP composition rule: an atom of curvature `target` keeps that curvature
+# when every argument is affine, matches `target` under an increasing slot, or
+# matches the flipped curvature under a decreasing slot.
+function composes_as(target::Curvature, f_monotonicity, args)
+    flipped = target == Convex ? Concave : Convex
+    return all(enumerate(args)) do (i, arg)
+        arg_curv = find_curvature(arg)
+        arg_curv == Affine && return true
+        m = get_arg_property(f_monotonicity, i, args)
+        if arg_curv == target
+            m == Increasing
+        elseif arg_curv == flipped
+            m == Decreasing
+        else
+            false
+        end
     end
 end
 
@@ -368,44 +390,16 @@ function find_curvature(ex)
         f_curvature = rule.curvature
         f_monotonicity = rule.monotonicity
 
-        if f_curvature == Affine
-            if all(enumerate(args)) do (i, arg)
-                    arg_curv = find_curvature(arg)
-                    arg_curv == Affine
-                end
-                return Affine
-            end
-        elseif f_curvature == Convex || f_curvature == Affine
-            if all(enumerate(args)) do (i, arg)
-                    arg_curv = find_curvature(arg)
-                    m = get_arg_property(f_monotonicity, i, args)
-                    # @show f_monotonicity
-                    # @show arg
-                    # @show m
-                    if arg_curv == Convex
-                        m == Increasing
-                    elseif arg_curv == Concave
-                        m == Decreasing
-                    else
-                        arg_curv == Affine
-                    end
-                end
-                return Convex
-            end
-        elseif f_curvature == Concave || f_curvature == Affine
-            if all(enumerate(args)) do (i, arg)
-                    arg_curv = find_curvature(arg)
-                    m = f_monotonicity[i]
-                    if arg_curv == Concave
-                        m == Increasing
-                    elseif arg_curv == Convex
-                        m == Decreasing
-                    else
-                        arg_curv == Affine
-                    end
-                end
-                return Concave
-            end
+        if f_curvature == Convex
+            return composes_as(Convex, f_monotonicity, args) ? Convex : UnknownCurvature
+        elseif f_curvature == Concave
+            return composes_as(Concave, f_monotonicity, args) ? Concave : UnknownCurvature
+        elseif f_curvature == Affine
+            # An affine atom composes both as a convex and as a concave one; it
+            # stays affine only when both hold, i.e. every argument is affine.
+            cvx = composes_as(Convex, f_monotonicity, args)
+            ccv = composes_as(Concave, f_monotonicity, args)
+            return cvx && ccv ? Affine : cvx ? Convex : ccv ? Concave : UnknownCurvature
         end
         return UnknownCurvature
     else

--- a/test/test.jl
+++ b/test/test.jl
@@ -79,3 +79,66 @@ ex = propagate_curvature(propagate_sign(cons[2].lhs))
 ex = SymbolicAnalysis.quad_over_lin(x - y, 1 - max(x, y)) |> unwrap
 ex = propagate_curvature(propagate_sign(ex))
 @test getcurvature(ex) == SymbolicAnalysis.Convex
+
+# Composition-rule regressions: affine atoms over non-affine arguments,
+# monotonicity tuples shorter than the argument list, and
+# value-of-p-dependent curvature for norm.
+
+@variables x y
+
+# Single-entry monotonicity tuples apply to every argument; previously the
+# second argument of max fell off the tuple (misclassified) and the concave
+# branch indexed the tuple directly (min of two variables threw).
+ex = max(y, x^2) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Convex
+
+ex = max(x^2, y) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Convex
+
+ex = min(x, y) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Concave
+
+ex = min(y, sqrt(x)) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Concave
+
+# Affine atoms compose as convex (concave) when their arguments do; previously
+# any non-affine argument of an affine atom returned UnknownCurvature.
+@variables X[1:3, 1:3]
+
+ex = tr(exp.(X)) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Convex
+
+ex = tr(log.(X)) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Concave
+
+ex = tr(X) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Affine
+
+# norm(x, p) curvature depends on the value of p: convex for p >= 1, concave
+# for 0 < p < 1 only on a nonnegative argument (unknown otherwise, previously
+# claimed convex), and unknown for p <= 0.
+@variables z[1:4]
+
+ex = norm(z, 2) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Convex
+
+ex = norm(z, 0.5) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.UnknownCurvature
+
+zpos = setmetadata(unwrap(z), SymbolicAnalysis.Sign, SymbolicAnalysis.Positive)
+ex = norm(Symbolics.wrap(zpos), 0.5) |> unwrap
+ex = propagate_curvature(ex)
+@test getcurvature(ex) == SymbolicAnalysis.Concave
+
+ex = norm(z, -1) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.UnknownCurvature


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Fixes four correctness bugs in the DCP rule engine, found by code review and confirmed with reproductions on unmodified `main`:

## 1. `min(x, y)` crashed the analyzer

The concave branch of `find_curvature` indexed the monotonicity tuple directly (`f_monotonicity[i]`) instead of going through `get_arg_property`. Since `add_dcprule` wraps a scalar monotonicity into a single-entry tuple, **any concave atom applied to two or more arguments threw a `BoundsError`** (surfacing as `RuleRewriteError`):

```julia
julia> analyze(unwrap(min(x, y)))
ERROR: Failed to apply rule ~x => setcurvature(~x, find_curvature(~x)) on expression min(x, y)
```

## 2. `max(y, x^2)` misclassified as `UnknownCurvature`

`get_arg_property` returned the whole tuple when `i > length(tuple)`, so for convex atoms every argument past the declared monotonicities failed the composition check. `max(x^2, y)` was correctly `Convex` but `max(y, x^2)` was `UnknownCurvature`. Both fixes: single-entry monotonicity tuples now apply their last entry to all remaining arguments, and both composition branches share one code path.

## 3. Affine atoms rejected non-affine arguments

The composition check was structured as `if f_curvature == Affine ... elseif f_curvature == Convex || f_curvature == Affine ...` — the `|| f_curvature == Affine` arms were unreachable dead code, so an affine atom over convex/concave arguments returned `UnknownCurvature` instead of composing:

```julia
julia> analyze(unwrap(tr(exp.(X)))).curvature
UnknownCurvature   # should be Convex
```

The branches are rewritten around a single `composes_as(target, monotonicity, args)` helper implementing the DCP composition rule; an affine atom now composes as convex, as concave, or stays affine when all arguments are affine.

## 4. `norm(x, p)` claimed `Convex` for `p < 1`

The `p ∈ [0, 1)` rule was marked `#incorrect for p<1` in a comment and classified as `Convex`, and the multi-rule domain lookup could never reach it anyway (it threw on the first non-matching rule; that loop is also fixed to try all rules before throwing). `norm` is now a value-of-`p`-dependent `dcprule` method like `^`: convex for `p ≥ 1`; for `0 < p < 1` concave when the argument is known `Positive` (the generalized p-"norm" is concave on the nonnegative orthant) and `UnknownCurvature` otherwise; `UnknownCurvature` for `p ≤ 0`.

## Tests

Regression tests added for all four (min/max monotonicity broadcast, affine composition through `tr`, and all `norm` cases). Full suite run locally: all tests pass (91 baseline + 11 new).

Found while reviewing the rule engine for the multi-discipline (DCP/DGP/DGCP) refactor discussed with Chris; further engine work (single-pass propagation, `sum`/`Mapreducer` handling on Symbolics v7) will come as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
