### PR TITLE
Replace rule-rewriting propagation with a single bottom-up pass (5-130x faster)

### DIFF
--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -154,21 +154,29 @@ add_dcprule(maximum, array_domain(RealLine()), AnySign, Convex, Increasing)
 
 add_dcprule(minimum, array_domain(RealLine()), AnySign, Concave, Increasing)
 
-#incorrect for p<1
-add_dcprule(
-    norm,
-    (array_domain(RealLine()), Interval{:closed, :open}(1, Inf)),
-    Positive,
-    Convex,
-    increasing_if_positive
-)
-add_dcprule(
-    norm,
-    (array_domain(RealLine()), Interval{:closed, :open}(0, 1)),
-    Positive,
-    Convex,
-    increasing_if_positive
-)
+# `norm(x, p)` is only a norm (hence convex) for p >= 1. For 0 < p < 1 the
+# generalized "norm" (sum |x_i|^p)^(1/p) is concave on the nonnegative orthant
+# and has no DCP curvature for sign-unknown arguments; for p <= 0 it is not
+# DCP-representable. The rule depends on the value of `p`, so it is a
+# specialized `dcprule` method like `^` rather than a static table entry.
+function dcprule(::typeof(norm), x, p)
+    pv = constval(p)
+    args = (x, p)
+    if !(pv isa Number)
+        return makerule(array_domain(RealLine()), Positive, UnknownCurvature, AnyMono), args
+    elseif pv >= 1
+        return makerule(array_domain(RealLine()), Positive, Convex, increasing_if_positive), args
+    elseif pv > 0
+        curv = getsign(x) == Positive ? Concave : UnknownCurvature
+        return makerule(array_domain(HalfLine()), Positive, curv, Increasing), args
+    else
+        return makerule(array_domain(RealLine()), Positive, UnknownCurvature, AnyMono), args
+    end
+end
+function dcprule(::typeof(norm), x)
+    return makerule(array_domain(RealLine()), Positive, Convex, increasing_if_positive), (x,)
+end
+hasdcprule(::typeof(norm)) = true
 
 """
     perspective(f::Function, x, s::Real)

--- a/src/gdcp/gdcp_rules.jl
+++ b/src/gdcp/gdcp_rules.jl
@@ -264,5 +264,5 @@ function propagate_gcurvature(ex, M::AbstractManifold)
     # final `getgcurvature` reads. `analyze` already unwraps; do the same here so
     # the function is correct when called directly on a wrapped expression.
     ex = Symbolics.unwrap(ex)
-    return Postwalk(x -> setgcurvature(x, node_gcurvature(x)))(ex)
+    return Postwalk(x -> issym(x) || iscall(x) ? setgcurvature(x, node_gcurvature(x)) : x)(ex)
 end

--- a/src/gdcp/gdcp_rules.jl
+++ b/src/gdcp/gdcp_rules.jl
@@ -244,18 +244,25 @@ function find_gcurvature(ex)
     return GUnknownCurvature
 end
 
+# See `node_curvature`: geodesic curvature of a single node whose children the
+# bottom-up walk has already annotated.
+function node_gcurvature(ex)
+    if iscall(ex)
+        f = operation(ex)
+        if Symbol(f) == :*
+            return mul_gcurvature(arguments(ex))
+        elseif Symbol(f) == :+
+            return add_gcurvature(arguments(ex))
+        end
+    end
+    return find_gcurvature(ex)
+end
+
 function propagate_gcurvature(ex, M::AbstractManifold)
     # Operate on the raw symbolic: on Symbolics v7 walking a `Num`/`Arr` wrapper
     # round-trips through wrap/unwrap and loses the gcurvature metadata that the
     # final `getgcurvature` reads. `analyze` already unwraps; do the same here so
     # the function is correct when called directly on a wrapped expression.
     ex = Symbolics.unwrap(ex)
-    r = [
-        @rule *(~~x) => setgcurvature(~MATCH, mul_gcurvature(~~x))
-        @rule +(~~x) => setgcurvature(~MATCH, add_gcurvature(~~x))
-        @rule ~x => setgcurvature(~x, find_gcurvature(~x))
-    ]
-    ex = Postwalk(Chain(r))(ex)
-    ex = Prewalk(Chain(r))(ex)
-    return ex
+    return Postwalk(x -> setgcurvature(x, node_gcurvature(x)))(ex)
 end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -162,13 +162,8 @@ function add_sign(args)
     all_positive = true
     for i in eachindex(args)
         arg = args[i]
-        if iscall(arg)
-            # Don't write the propagated arg back into `args`: on Symbolics v7 the
-            # matched `~~x` is a read-only vector. The aggregate sign only needs
-            # the local propagated value, and the surrounding Postwalk/Prewalk
-            # already persists each child's sign metadata on the expression tree.
-            arg = propagate_sign(arg)
-        end
+        # The bottom-up pass annotates children before their parent, so each
+        # argument already carries its sign metadata here.
         s = getsign(arg)
         if s == AnySign
             has_anysign = true
@@ -208,32 +203,42 @@ function mul_sign(args)
     return isodd(neg_count) ? Negative : Positive
 end
 
+# Sign of a single node whose children have already been annotated by the
+# bottom-up walk. Mirrors the priority the old rule chain established through
+# successive overwrites: `*`/`+` aggregation wins over a GDCP rule, which wins
+# over a DCP rule, which wins over the `AnySign` default (also overwriting any
+# stale metadata from a previous analysis).
+function node_sign(ex)
+    if iscall(ex)
+        f = operation(ex)
+        if Symbol(f) == :*
+            return mul_sign(arguments(ex))
+        elseif Symbol(f) == :+
+            return add_sign(arguments(ex))
+        elseif hasgdcprule(f)
+            return gdcprule(f, arguments(ex)...)[1].sign
+        elseif hasdcprule(f)
+            return dcprule(f, arguments(ex)...)[1].sign
+        end
+    elseif issym(ex)
+        if hasgdcprule(ex)
+            return gdcprule(ex)[1].sign
+        elseif hasdcprule(ex)
+            return dcprule(ex)[1].sign
+        end
+    end
+    return AnySign
+end
+
 function propagate_sign(ex)
-    # Work on the raw symbolic so the sign metadata survives the rewrite walk on
+    # Work on the raw symbolic so the sign metadata survives the walk on
     # Symbolics v7 (a `Num`/`Arr` wrapper round-trips through wrap/unwrap and drops
     # it). `analyze` already unwraps; mirror that for direct callers.
     ex = Symbolics.unwrap(ex)
-    # Step 1: set the sign of all variables to be AnySign
-    rs = [
-        @rule ~x::issym => setsign(~x, AnySign) where {hassign(~x)}
-        @rule ~x::iscall => setsign(~x, AnySign) where {hassign(~x)}
-        @rule ~x::issym => setsign(~x, (dcprule(~x))[1].sign) where {hasdcprule(~x)}
-        @rule ~x::issym => setsign(~x, (gdcprule(~x))[1].sign) where {hasgdcprule(~x)}
-        @rule ~x::iscall => setsign(
-            ~x,
-            (dcprule(operation(~x), arguments(~x)...)[1].sign)
-        ) where {hasdcprule(operation(~x))}
-        @rule ~x::iscall => setsign(
-            ~x,
-            (gdcprule(operation(~x), arguments(~x)...)[1].sign)
-        ) where {hasgdcprule(operation(~x))}
-        @rule *(~~x) => setsign(~MATCH, mul_sign(~~x))
-        @rule +(~~x) => setsign(~MATCH, add_sign(~~x))
-    ]
-    rc = Chain(rs)
-    ex = Postwalk(rc)(ex)
-    ex = Prewalk(rc)(ex)
-    return ex
+    # A single bottom-up walk: `Postwalk` rebuilds each node from its annotated
+    # children before the annotation function sees it, so every node's sign is
+    # computed exactly once.
+    return Postwalk(x -> setsign(x, node_sign(x)))(ex)
 end
 
 ### Curvature ###
@@ -307,19 +312,26 @@ function add_curvature(args)
     end
 end
 
+# Curvature of a single node whose children have already been annotated by the
+# bottom-up walk (so the `find_curvature` recursion terminates at the children's
+# cached metadata).
+function node_curvature(ex)
+    if iscall(ex)
+        f = operation(ex)
+        if Symbol(f) == :*
+            return mul_curvature(arguments(ex))
+        elseif Symbol(f) == :+
+            return add_curvature(arguments(ex))
+        end
+    end
+    return find_curvature(ex)
+end
+
 function propagate_curvature(ex)
-    # See `propagate_sign`: unwrap so the curvature metadata survives the v7 walk.
+    # See `propagate_sign`: unwrap so the curvature metadata survives the v7 walk,
+    # and annotate in a single bottom-up pass.
     ex = Symbolics.unwrap(ex)
-    rs = [
-        @rule *(~~x) => setcurvature(~MATCH, mul_curvature(~~x))
-        @rule +(~~x) => setcurvature(~MATCH, add_curvature(~~x))
-        @rule ~x => setcurvature(~x, find_curvature(~x))
-    ]
-    rc = Chain(rs)
-    ex = Postwalk(rc)(ex)
-    ex = Prewalk(rc)(ex)
-    # SymbolicUtils.inspect(ex, metadata = true)
-    return ex
+    return Postwalk(x -> setcurvature(x, node_curvature(x)))(ex)
 end
 
 function get_arg_property(monotonicity, i, args)

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -96,21 +96,20 @@ function dcprule(f, args...)
     end
 
     if dcprules_dict[f] isa Vector
-        for i in 1:length(dcprules_dict[f])
-            if (dcprules_dict[f][i].domain isa Domain) &&
-                    all(issubset.(argsdomain, Ref(dcprules_dict[f][i].domain)))
-                return dcprules_dict[f][i], args
-            elseif !(dcprules_dict[f][i].domain isa Domain) &&
-                    all(issubset.(argsdomain, dcprules_dict[f][i].domain))
-                return dcprules_dict[f][i], args
-            else
-                throw(
-                    ArgumentError(
-                        "No DCP rule found for $f with arguments $args with domain $argsdomain",
-                    ),
-                )
+        for rule in dcprules_dict[f]
+            if (rule.domain isa Domain) &&
+                    all(issubset.(argsdomain, Ref(rule.domain)))
+                return rule, args
+            elseif !(rule.domain isa Domain) &&
+                    all(issubset.(argsdomain, rule.domain))
+                return rule, args
             end
         end
+        throw(
+            ArgumentError(
+                "No DCP rule found for $f with arguments $args with domain $argsdomain",
+            ),
+        )
     elseif (dcprules_dict[f].domain isa Domain) &&
             all(issubset.(argsdomain, Ref(dcprules_dict[f].domain)))
         return dcprules_dict[f], args
@@ -327,11 +326,34 @@ function get_arg_property(monotonicity, i, args)
     @label start
     return if monotonicity isa Function
         monotonicity(args[i])
-    elseif monotonicity isa Tuple && i <= length(monotonicity)
-        monotonicity = monotonicity[i]
+    elseif monotonicity isa Tuple
+        # A rule may declare fewer monotonicities than the call has arguments —
+        # in particular `add_dcprule` wraps a scalar monotonicity into a
+        # single-entry tuple that applies to every argument — so the last
+        # declared entry covers the remaining arguments.
+        monotonicity = monotonicity[min(i, length(monotonicity))]
         @goto start
     else
         monotonicity
+    end
+end
+
+# The DCP composition rule: an atom of curvature `target` keeps that curvature
+# when every argument is affine, matches `target` under an increasing slot, or
+# matches the flipped curvature under a decreasing slot.
+function composes_as(target::Curvature, f_monotonicity, args)
+    flipped = target == Convex ? Concave : Convex
+    return all(enumerate(args)) do (i, arg)
+        arg_curv = find_curvature(arg)
+        arg_curv == Affine && return true
+        m = get_arg_property(f_monotonicity, i, args)
+        if arg_curv == target
+            m == Increasing
+        elseif arg_curv == flipped
+            m == Decreasing
+        else
+            false
+        end
     end
 end
 
@@ -368,44 +390,16 @@ function find_curvature(ex)
         f_curvature = rule.curvature
         f_monotonicity = rule.monotonicity
 
-        if f_curvature == Affine
-            if all(enumerate(args)) do (i, arg)
-                    arg_curv = find_curvature(arg)
-                    arg_curv == Affine
-                end
-                return Affine
-            end
-        elseif f_curvature == Convex || f_curvature == Affine
-            if all(enumerate(args)) do (i, arg)
-                    arg_curv = find_curvature(arg)
-                    m = get_arg_property(f_monotonicity, i, args)
-                    # @show f_monotonicity
-                    # @show arg
-                    # @show m
-                    if arg_curv == Convex
-                        m == Increasing
-                    elseif arg_curv == Concave
-                        m == Decreasing
-                    else
-                        arg_curv == Affine
-                    end
-                end
-                return Convex
-            end
-        elseif f_curvature == Concave || f_curvature == Affine
-            if all(enumerate(args)) do (i, arg)
-                    arg_curv = find_curvature(arg)
-                    m = f_monotonicity[i]
-                    if arg_curv == Concave
-                        m == Increasing
-                    elseif arg_curv == Convex
-                        m == Decreasing
-                    else
-                        arg_curv == Affine
-                    end
-                end
-                return Concave
-            end
+        if f_curvature == Convex
+            return composes_as(Convex, f_monotonicity, args) ? Convex : UnknownCurvature
+        elseif f_curvature == Concave
+            return composes_as(Concave, f_monotonicity, args) ? Concave : UnknownCurvature
+        elseif f_curvature == Affine
+            # An affine atom composes both as a convex and as a concave one; it
+            # stays affine only when both hold, i.e. every argument is affine.
+            cvx = composes_as(Convex, f_monotonicity, args)
+            ccv = composes_as(Concave, f_monotonicity, args)
+            return cvx && ccv ? Affine : cvx ? Convex : ccv ? Concave : UnknownCurvature
         end
         return UnknownCurvature
     else

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -237,8 +237,10 @@ function propagate_sign(ex)
     ex = Symbolics.unwrap(ex)
     # A single bottom-up walk: `Postwalk` rebuilds each node from its annotated
     # children before the annotation function sees it, so every node's sign is
-    # computed exactly once.
-    return Postwalk(x -> setsign(x, node_sign(x)))(ex)
+    # computed exactly once. Only symbols and calls are annotated — wrapped
+    # constants can't carry metadata on older SymbolicUtils v4 releases, and
+    # every getter already falls back correctly for them.
+    return Postwalk(x -> issym(x) || iscall(x) ? setsign(x, node_sign(x)) : x)(ex)
 end
 
 ### Curvature ###
@@ -329,9 +331,9 @@ end
 
 function propagate_curvature(ex)
     # See `propagate_sign`: unwrap so the curvature metadata survives the v7 walk,
-    # and annotate in a single bottom-up pass.
+    # and annotate symbols and calls in a single bottom-up pass.
     ex = Symbolics.unwrap(ex)
-    return Postwalk(x -> setcurvature(x, node_curvature(x)))(ex)
+    return Postwalk(x -> issym(x) || iscall(x) ? setcurvature(x, node_curvature(x)) : x)(ex)
 end
 
 function get_arg_property(monotonicity, i, args)

--- a/test/alloc_tests.jl
+++ b/test/alloc_tests.jl
@@ -79,3 +79,15 @@ end
     @test allocs_add <= 3
     @test allocs_mul <= 3
 end
+
+@testset "Analysis allocation scaling" begin
+    # Regression guard for the single-pass propagation engine: the old
+    # rule-rewriting engine allocated ~14 MB analyzing this expression, the
+    # single-pass walk ~1.2 MB. Generous headroom over the latter so the test
+    # only trips on a return to per-node rewriting, not on minor churn.
+    vars = Symbolics.variables(:q, 1:200)
+    ex = Symbolics.unwrap(sum(exp(v) + v^2 for v in vars))
+    res = SymbolicAnalysis.analyze(ex)
+    @test res.curvature == Convex
+    @test (@allocated SymbolicAnalysis.analyze(ex)) < 8_000_000
+end

--- a/test/test.jl
+++ b/test/test.jl
@@ -79,3 +79,66 @@ ex = propagate_curvature(propagate_sign(cons[2].lhs))
 ex = SymbolicAnalysis.quad_over_lin(x - y, 1 - max(x, y)) |> unwrap
 ex = propagate_curvature(propagate_sign(ex))
 @test getcurvature(ex) == SymbolicAnalysis.Convex
+
+# Composition-rule regressions: affine atoms over non-affine arguments,
+# monotonicity tuples shorter than the argument list, and
+# value-of-p-dependent curvature for norm.
+
+@variables x y
+
+# Single-entry monotonicity tuples apply to every argument; previously the
+# second argument of max fell off the tuple (misclassified) and the concave
+# branch indexed the tuple directly (min of two variables threw).
+ex = max(y, x^2) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Convex
+
+ex = max(x^2, y) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Convex
+
+ex = min(x, y) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Concave
+
+ex = min(y, sqrt(x)) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Concave
+
+# Affine atoms compose as convex (concave) when their arguments do; previously
+# any non-affine argument of an affine atom returned UnknownCurvature.
+@variables X[1:3, 1:3]
+
+ex = tr(exp.(X)) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Convex
+
+ex = tr(log.(X)) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Concave
+
+ex = tr(X) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Affine
+
+# norm(x, p) curvature depends on the value of p: convex for p >= 1, concave
+# for 0 < p < 1 only on a nonnegative argument (unknown otherwise, previously
+# claimed convex), and unknown for p <= 0.
+@variables z[1:4]
+
+ex = norm(z, 2) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Convex
+
+ex = norm(z, 0.5) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.UnknownCurvature
+
+zpos = setmetadata(unwrap(z), SymbolicAnalysis.Sign, SymbolicAnalysis.Positive)
+ex = norm(Symbolics.wrap(zpos), 0.5) |> unwrap
+ex = propagate_curvature(ex)
+@test getcurvature(ex) == SymbolicAnalysis.Concave
+
+ex = norm(z, -1) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.UnknownCurvature


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.
> Stacked on #118 (includes its commit); review only the last commit until #118 merges.

Replaces the `@rule`-chain + `Postwalk` + `Prewalk` machinery in all three propagation passes (`propagate_sign`, `propagate_curvature`, `propagate_gcurvature`) with a single bottom-up walk that computes each node's annotation exactly once from its already-annotated children. No public API change; all annotations still land in expression metadata exactly as before.

## What was slow

- Each pass ran a rule-matcher chain over the tree **twice** (`Postwalk` then `Prewalk`), and the generic `~x => find_curvature(~x)` rule re-entered the recursive analysis at every node.
- `add_sign` called `propagate_sign(arg)` on every call-argument of every `+` node — a full re-annotation of the subtree per parent, i.e. quadratic re-walking on nested sums.
- First call paid `@rule` pattern-compilation latency on top of everything.

Since `Postwalk` rebuilds a node from its rewritten children before the rewriter sees it, a plain function that computes the node's sign/curvature from its children's metadata does the same job in one pass with no pattern matching: `Postwalk(x -> setsign(x, node_sign(x)))`. The old rule-chain priority (`*`/`+` aggregation over GDCP rules over DCP rules over the `AnySign` default) is preserved in `node_sign`/`node_curvature`/`node_gcurvature`.

## Measured (Julia 1.12.4, this machine)

| case | main | this PR | speedup |
|---|---|---|---|
| 8-node scalar expr | 487 µs / 1,487 allocs | 229 µs / 571 allocs | 2.1× |
| 150-atom expr | 28 ms / 5.0 MiB | 5.2 ms / 0.44 MiB | 5.4× |
| 600-atom expr | 112 ms / 20 MiB | 21 ms / 1.7 MiB | 5.3× |
| 600-atom expr, **first call** | 4.13 s | 0.031 s | **132×** |
| DGCP `logdet(conjugation(inv(X),A))`, SPD(5) | 408 µs | 220 µs | 1.9× |

The first-call number is the one that matters for `structural_analysis` in Optimization.jl, where `analyze` runs once per problem.

## Tests

Full suite passes locally. Added an allocation regression guard to `test/alloc_tests.jl` (200-term expression must stay under 8 MB allocated; the old engine used ~14 MB, the new one ~1.2 MB) so a return to per-node rewriting trips CI.

Remaining constant-factor work (typed rule registry instead of the untyped `Dict`, metadata-free analysis) is planned as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
