### PR TITLE
Recognize Mapreducer/Mapper operations for sum/map over symbolic arrays

### DIFF
--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -583,3 +583,20 @@ hasdcprule(::typeof(broadcast)) = true
 
 add_dcprule(LinearAlgebra.adjoint, array_domain(RealLine(), 1), AnySign, Affine, Increasing)
 add_dcprule(Base.getindex, array_domain(RealLine(), 1), AnySign, Affine, AnyMono)
+
+# On Symbolics v7 / SymbolicUtils v4, reductions and maps over symbolic arrays
+# trace to `SymbolicUtils.Mapreducer`/`SymbolicUtils.Mapper` operations rather
+# than to `sum`/`map` themselves, so the static rule table never sees them.
+# A plain sum — `mapreduce(identity, add_sum, x)`
+# for any `dims`/`init` — delegates to the registered `sum` rule (an `init`
+# only shifts by a constant, which preserves the affine composition), and
+# `map(f, xs...)` delegates to `f`'s rule exactly like `broadcast`.
+hasdcprule(::SymbolicUtils.Mapreducer{typeof(identity), typeof(Base.add_sum)}) = true
+function dcprule(
+        ::SymbolicUtils.Mapreducer{typeof(identity), typeof(Base.add_sum)}, args...
+    )
+    return dcprules_dict[sum], args
+end
+
+hasdcprule(op::SymbolicUtils.Mapper) = hasdcprule(op.f)
+dcprule(op::SymbolicUtils.Mapper, args...) = dcprule(op.f, args...)

--- a/test/test.jl
+++ b/test/test.jl
@@ -142,3 +142,22 @@ ex = propagate_curvature(ex)
 ex = norm(z, -1) |> unwrap
 ex = propagate_curvature(propagate_sign(ex))
 @test getcurvature(ex) == SymbolicAnalysis.UnknownCurvature
+
+# sum/map over symbolic arrays trace to SymbolicUtils.Mapreducer/Mapper
+# operations, not to `sum`/`map` themselves; previously they always analyzed
+# as UnknownCurvature.
+ex = sum(exp.(z)) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Convex
+
+ex = sum(log.(z)) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Concave
+
+ex = sum(z) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Affine
+
+ex = map(exp, z) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Convex


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

On Symbolics v7 / SymbolicUtils v4, `sum(x)` and `map(f, x)` over symbolic arrays trace to terms whose `operation` is a `SymbolicUtils.Mapreducer` / `SymbolicUtils.Mapper` callable rather than `sum`/`map` itself, so the rule table never matched them and **every array reduction analyzed as `UnknownCurvature`** — e.g. `analyze(unwrap(sum(exp.(z))))` returned unknown instead of `Convex`. The registered `add_dcprule(sum, ...)` entry was dead code for traced expressions.

- A plain sum (`mapreduce(identity, add_sum, x)`, any `dims`/`init` — an `init` only shifts by a constant, preserving affine composition) delegates to the registered `sum` rule.
- `map(f, xs...)` delegates to `f`'s rule, exactly like the existing `broadcast` delegation.
- `sum(f, x)` with non-identity `f` stays conservative (`UnknownCurvature`) for now.

Verified locally: `sum(exp.(z))` → Convex, `sum(log.(z))` → Concave, `sum(z)` / `sum(z; dims=1)` → Affine, `map(exp, z)` → Convex; tests added and the full suite passes (Core/test.jl 36/36).

Rebased 2026-07-12 onto `main` now that #118 and #119 have merged — this is now a single self-contained commit touching only `src/atoms.jl` and `test/test.jl`.

Public-API note: `Mapper`/`Mapreducer` are currently non-public SymbolicUtils names; JuliaSymbolics/SymbolicUtils.jl#1006 promotes them to documented public API (docstrings + `@public` + API docs). This PR is functional regardless, but the dependency becomes policy-clean once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
