### PR TITLE
Remove stray debug println output that fires during analysis

### DIFF
--- a/src/gdcp/lorentz.jl
+++ b/src/gdcp/lorentz.jl
@@ -142,9 +142,7 @@ function lorentz_nonhomogeneous_quadratic(
 
     # This call will check if A satisfies the geodesic convexity conditions
     homogeneous_part = lorentz_homogeneous_quadratic(A, p)
-    println(size(homogeneous_part))
     affine_part = (Matrix(b') * p)
-    println(size(affine_part))
     return homogeneous_part + affine_part[1] + c
 end
 

--- a/src/lianalg.jl
+++ b/src/lianalg.jl
@@ -22,6 +22,5 @@ function LinearAlgebra._chol!(x::Num, uplo)
     rxr = sqrt(abs(rx))
     rval = convert(promote_type(typeof(x), typeof(rxr)), rxr)
     d = rx - abs(x) |> simplify
-    println(d)
     return isapprox(d, 0.0) ? (rval, convert(BlasInt, 0)) : (rval, convert(BlasInt, 1))
 end


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

First cleanup item from the Phase 1 list in #121. Removes three stray debug `println`s that fire during normal analysis/evaluation:

- `src/lianalg.jl:25` — `println(d)` inside `LinearAlgebra._chol!(::Num, uplo)`, printing the simplified residual on every symbolic Cholesky check.
- `src/gdcp/lorentz.jl:145,147` — `println(size(...))` inside `lorentz_nonhomogeneous_quadratic`.

Each printed value is still computed and used on the following line, so the removals are behavior-preserving (`d` feeds the `isapprox` return; `homogeneous_part`/`affine_part` feed the sum). No other executing debug output remains in `src/` (only two commented-out `# @show` lines, left untouched to keep this PR scoped to output that actually fires).

Full test suite run locally: all pass.

Part of #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
