### PR TITLE
Recognize max/min reductions so maximum/minimum over arrays analyze

### DIFF
--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -598,5 +598,20 @@ function dcprule(
     return dcprules_dict[sum], args
 end
 
+# `maximum`/`minimum` over a symbolic array reduce with `max`/`min`, so they
+# trace to `Mapreducer{identity, max}` / `Mapreducer{identity, min}` and, like
+# `sum`, never reach the `maximum`/`minimum` rules directly. Reducing over any
+# `dims` preserves the convex-increasing / concave-increasing curvature, so
+# delegate to the registered rule regardless of `dims`/`init`.
+hasdcprule(::SymbolicUtils.Mapreducer{typeof(identity), typeof(max)}) = true
+function dcprule(::SymbolicUtils.Mapreducer{typeof(identity), typeof(max)}, args...)
+    return dcprules_dict[maximum], args
+end
+
+hasdcprule(::SymbolicUtils.Mapreducer{typeof(identity), typeof(min)}) = true
+function dcprule(::SymbolicUtils.Mapreducer{typeof(identity), typeof(min)}, args...)
+    return dcprules_dict[minimum], args
+end
+
 hasdcprule(op::SymbolicUtils.Mapper) = hasdcprule(op.f)
 dcprule(op::SymbolicUtils.Mapper, args...) = dcprule(op.f, args...)

--- a/test/test.jl
+++ b/test/test.jl
@@ -161,3 +161,20 @@ ex = propagate_curvature(propagate_sign(ex))
 ex = map(exp, z) |> unwrap
 ex = propagate_curvature(propagate_sign(ex))
 @test getcurvature(ex) == SymbolicAnalysis.Convex
+
+# maximum/minimum over symbolic arrays reduce with max/min, tracing to
+# SymbolicUtils.Mapreducer{identity, max}/{identity, min} rather than
+# maximum/minimum; previously they analyzed as UnknownCurvature.
+@variables z[1:4]
+
+ex = maximum(z) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Convex
+
+ex = minimum(z) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Concave
+
+ex = maximum(exp.(z)) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Convex


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Direct follow-on to #120. Surfaced by the MVP trace-coverage spike in #121: `maximum(z)` and `minimum(z)` over a symbolic array analyzed as `UnknownCurvature`.

Cause: like `sum`, `maximum`/`minimum` over a symbolic array do not trace to `maximum`/`minimum` — they reduce with `max`/`min` and trace to `SymbolicUtils.Mapreducer{typeof(identity), typeof(max)}` / `{typeof(identity), typeof(min)}`. #120 taught the rule table about the `add_sum` reducer (`sum`) but not `max`/`min`, so the registered `maximum`/`minimum` rules were never reached.

This delegates the `max`/`min` reducers to the existing `maximum`/`minimum` rules. Reducing over any `dims` preserves convex-increasing (`maximum`) / concave-increasing (`minimum`) curvature, so the delegation is `dims`/`init`-independent, matching #120's handling of `sum`.

Verified locally: `maximum(z)` → Convex, `minimum(z)` → Concave, `maximum(exp.(z))` → Convex, `minimum(log.(z))` → Concave, `maximum(z; dims=1)` → Convex. Tests added; full suite passes.

Part of #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
