### PR TITLE
Remove incorrect logistic (sigmoid) convexity rule

### DIFF
--- a/docs/src/atoms.md
+++ b/docs/src/atoms.md
@@ -47,7 +47,6 @@ This page is intended to be a reference for the atoms that are currently impleme
 | kldivergence              | (array_domain(HalfLine{Real,:open}, 1), array_domain(HalfLine{Real,:open}, 1)) | Positive  | Convex    | AnyMono                                     |
 | lognormcdf                | ℝ                                                                              | Negative  | Concave   | Increasing                                  |
 | log1p                     | Interval{:open,:open}(-1, Inf)                                                 | Negative  | Concave   | Increasing                                  |
-| logistic                  | ℝ                                                                              | Positive  | Convex    | Increasing                                  |
 | max                       | (ℝ, ℝ)                                                                         | AnySign   | Convex    | Increasing                                  |
 | min                       | (ℝ, ℝ)                                                                         | AnySign   | Concave   | Increasing                                  |
 | ^(x, i)                   | See below                                                                      | See below | See below | See below                                   |

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -482,8 +482,6 @@ add_dcprule(lognormcdf, RealLine(), Negative, Concave, Increasing)
 
 add_dcprule(log1p, Interval{:open, :open}(-1, Inf), Negative, Concave, Increasing)
 
-add_dcprule(logistic, RealLine(), Positive, Convex, Increasing)
-
 add_dcprule(max, (RealLine(), RealLine()), AnySign, Convex, Increasing)
 add_dcprule(min, (RealLine(), RealLine()), AnySign, Concave, Increasing)
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -178,3 +178,13 @@ ex = propagate_curvature(propagate_sign(ex))
 ex = maximum(exp.(z)) |> unwrap
 ex = propagate_curvature(propagate_sign(ex))
 @test getcurvature(ex) == SymbolicAnalysis.Convex
+
+# logistic (the sigmoid 1/(1+exp(-x))) is NOT globally convex: f'' is positive
+# for x<0, zero at x=0, negative for x>0 (inflection at 0), so no single-curvature
+# DCP rule is valid. The rule was dead today (logistic expands to `/`) but a latent
+# trap: it must carry no rule and analyze as UnknownCurvature, not a false Convex.
+@variables x
+@test !SymbolicAnalysis.hasdcprule(logistic)
+ex = logistic(x) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.UnknownCurvature


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Surfaced by the trace-coverage spike in #121. `logistic` (the sigmoid `1/(1+exp(-x))`, from LogExpFunctions) was registered as `Convex`, but the sigmoid is **not globally convex**: its second derivative `s(1-s)(1-2s)` is positive for `x<0`, zero at `x=0`, and negative for `x>0` (inflection at the origin). Verified numerically:

```
logistic''(-3) = +0.041   logistic''(-1) = +0.091   logistic''(0) = 0   logistic''(+1) = -0.091   logistic''(+3) = -0.041
```

The rule looks like a sigmoid-vs-softplus mix-up (the logistic *loss* / softplus `log(1+exp(x))` is convex; the sigmoid is not). The rule is **dead today** — `logistic(x)` expands to a `/` expression during tracing, so it never fires and `analyze` already returns `UnknownCurvature` — but it is a **latent trap**: `hasdcprule(logistic)` is `true`, so anyone later preserving `logistic` as a symbolic atom would silently activate a false `Convex` certification.

Removes the rule (`src/atoms.jl`) and its docs row (`docs/src/atoms.md`). Behavior-preserving for `analyze` output (still `UnknownCurvature`); it removes the trap. Test asserts `!hasdcprule(logistic)` (fails before, passes after) and the honest `UnknownCurvature` result. Full suite passes.

Part of #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
