### PR TITLE
Remove dead code in the DGCP geodesic-curvature engine

### DIFF
--- a/src/gdcp/gdcp_rules.jl
+++ b/src/gdcp/gdcp_rules.jl
@@ -204,7 +204,7 @@ function find_gcurvature(ex)
             else
                 return GUnknownCurvature
             end
-        elseif f_curvature == Concave || f_curvature == Affine
+        elseif f_curvature == Concave
             if all(enumerate(args)) do (i, arg)
                     arg_curv = find_gcurvature(arg)
                     m = f_monotonicity[i]
@@ -217,15 +217,6 @@ function find_gcurvature(ex)
                     end
                 end
                 return GConcave
-            else
-                return GUnknownCurvature
-            end
-        elseif f_curvature == Affine
-            if all(enumerate(args)) do (i, arg)
-                    arg_curv = find_gcurvature(arg)
-                    arg_curv == GLinear
-                end
-                return GLinear
             else
                 return GUnknownCurvature
             end

--- a/src/gdcp/spd.jl
+++ b/src/gdcp/spd.jl
@@ -190,8 +190,6 @@ add_gdcprule(log_quad_form, SymmetricPositiveDefinite, Positive, GConvex, GIncre
 
 add_gdcprule(inv, SymmetricPositiveDefinite, Positive, GConvex, GDecreasing)
 
-add_gdcprule(diag, SymmetricPositiveDefinite, Positive, GConvex, GIncreasing)
-
 # Matrix `log` (both `Arr` and `Matrix{Num}` forms) is defined in atoms.jl via
 # `matrix_atom`; the `@register_array_symbolic` form collides with SymbolicUtils'
 # scalar `log` on Symbolics v7 (see the note there).


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Two behavior-preserving dead-code removals in the DGCP geodesic-curvature engine (`find_gcurvature`), from the "trivial DGCP correctness fixes" item in #121.

- **Delete the unreachable `elseif f_curvature == Affine` branch (`src/gdcp/gdcp_rules.jl`).** The dispatch chain opens with `if f_curvature == Convex || f_curvature == Affine` (line 190), which catches every `Affine` atom first, so the later `elseif f_curvature == Affine` block (was lines 223–231) can never run. The `|| f_curvature == Affine` disjunct on the `Concave` branch (line 207) is dead for the same reason and is dropped. Removing both is a pure no-op — `Affine` atoms continue to be handled by the line-190 branch exactly as before.
- **Delete the duplicate `diag` gDCP registration (`src/gdcp/spd.jl:193`).** `add_gdcprule(diag, SymmetricPositiveDefinite, Positive, GConvex, GIncreasing)` is byte-identical to the `add_gdcprule(LinearAlgebra.diag, …)` at line 69 (`diag === LinearAlgebra.diag` under `using LinearAlgebra`), and `gdcprules_dict` is keyed by function, so the second registration only overwrote the first with the same value. Removing it changes nothing.

Verified locally: the Core group (including `test/dgp.jl` and `test/lorentz.jl`, the DGCP coverage) passes unchanged.

### Noted for your call, deliberately not touched here

- **`sum_log_eigmax` branch (`gdcp_rules.jl:126–131`).** `if dcprule(operation(args[1])) == Convex` compares a `(rule, args)` tuple against the `Convex` enum, so it is always false, and `operation(args[1])` would throw if `args[1]` is a `Function`. The branch appears unreachable (registered `sum_log_eigmax` atoms are handled earlier at line 107) and can currently only error or return `GUnknownCurvature`. I left it untouched because deleting it vs. repairing it to a well-typed inner-atom-curvature check (`rule, _ = dcprule(operation(args[k])); rule.curvature == Convex ? GConvex : GUnknownCurvature`, with corrected arg indexing) depends on the intended semantics, which isn't clear from the code — happy to do either once you confirm intent.
- **`gdcprules_dict` manifold-key collision.** `distance` is registered for both SPD (`spd.jl`) and Lorentz (`lorentz.jl`) under the same function-only key, so the second overwrites the first. This is currently **behaviorally inert** — the stored `manifold` field is never read anywhere (`grep '.manifold' src/` is empty) and both registrations store identical `(Positive, GConvex, …)` values — so it is a latent smell, not an active bug. A proper `(function, manifold)` rekey is non-trivial (the sign pass `propagate_sign` has no manifold in scope, so the lookup would need `M` threaded through or a manifold-agnostic sign fallback) and is left for its own PR rather than lumped into this cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
