### PR TITLE
Preserve logsumexp as an atom and fix its domain

### DIFF
--- a/docs/src/atoms.md
+++ b/docs/src/atoms.md
@@ -16,7 +16,7 @@ This page is intended to be a reference for the atoms that are currently impleme
 | eigsummax                 | (array_domain(ℝ, 2), ℝ)                                                        | AnySign   | Convex    | AnyMono                                     |
 | eigsummin                 | (array_domain(ℝ, 2), ℝ)                                                        | AnySign   | Concave   | AnyMono                                     |
 | logdet                    | semidefinite_domain()                                                          | AnySign   | Concave   | AnyMono                                     |
-| LogExpFunctions.logsumexp | array_domain(ℝ, 2)                                                             | AnySign   | Convex    | Increasing                                  |
+| LogExpFunctions.logsumexp | array_domain(ℝ)                                                                | AnySign   | Convex    | Increasing                                  |
 | matrix_frac               | (array_domain(ℝ, 1), definite_domain())                                        | AnySign   | Convex    | AnyMono                                     |
 | maximum                   | array_domain(ℝ)                                                                | AnySign   | Convex    | Increasing                                  |
 | minimum                   | array_domain(ℝ)                                                                | AnySign   | Concave   | Increasing                                  |

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -117,9 +117,24 @@ add_dcprule(eigsummin, (array_domain(RealLine(), 2), RealLine()), AnySign, Conca
 
 add_dcprule(logdet, semidefinite_domain(), AnySign, Concave, AnyMono)
 
+# `LogExpFunctions.logsumexp` on a symbolic vector must stay an unevaluated
+# `logsumexp` term so the curvature pass can dispatch on it; Symbolics' own
+# vector method expands it to `log(sum(exp, x))`, which erases the atom and
+# leaves the expression UnknownCurvature. Dispatching on the concrete
+# `Symbolics.Arr` is strictly more specific, so this extends rather than
+# overwrites, and — unlike a `@register_symbolic ::Vector{Num}` form — emits no
+# scalar `BasicSymbolic{SymReal}` method that could clobber the scalar `logsumexp`.
+function LogExpFunctions.logsumexp(x::Symbolics.Arr)
+    return Symbolics.wrap(
+        SymbolicUtils.term(LogExpFunctions.logsumexp, Symbolics.unwrap(x); type = Real)
+    )
+end
+
+# `array_domain(RealLine())` (dimension-agnostic) not `..., 2)`: logsumexp is a
+# vector reduction, so requiring `ndims == 2` never matched a 1-D vector.
 add_dcprule(
     LogExpFunctions.logsumexp,
-    array_domain(RealLine(), 2),
+    array_domain(RealLine()),
     AnySign,
     Convex,
     Increasing

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -14,7 +14,7 @@ const SYMBOLIC_OWN = Any[
     SA.LinearAlgebra.inv, SA.LinearAlgebra.logdet,
     SA.Symbolics.arguments, SA.Symbolics.hasmetadata, SA.Symbolics.promote_symtype,
     SA.SymbolicUtils.promote_shape,
-    SA.Manifolds.distance, SA.LogExpFunctions.xlogx,
+    SA.Manifolds.distance, SA.LogExpFunctions.xlogx, SA.LogExpFunctions.logsumexp,
 ]
 
 run_qa(

--- a/test/test.jl
+++ b/test/test.jl
@@ -178,3 +178,15 @@ ex = propagate_curvature(propagate_sign(ex))
 ex = maximum(exp.(z)) |> unwrap
 ex = propagate_curvature(propagate_sign(ex))
 @test getcurvature(ex) == SymbolicAnalysis.Convex
+
+# logsumexp over a symbolic vector must stay an unevaluated atom — Symbolics'
+# own method expands it to log(sum(exp, z)), erasing the atom and yielding
+# UnknownCurvature; logsumexp itself is convex. (Also fixes the rule domain,
+# which required ndims==2 and so never matched a vector.)
+@variables z[1:4]
+
+@test Symbolics.operation(LogExpFunctions.logsumexp(z) |> unwrap) === LogExpFunctions.logsumexp
+
+ex = LogExpFunctions.logsumexp(z) |> unwrap
+ex = propagate_curvature(propagate_sign(ex))
+@test getcurvature(ex) == SymbolicAnalysis.Convex


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Surfaced by the trace-coverage spike in #121: `logsumexp(z)` over a symbolic vector analyzed as `UnknownCurvature`. Two causes:

1. **Atom not preserved.** `LogExpFunctions.logsumexp(z)` on a symbolic vector expands to `log(sum(exp, z))` (`operation` becomes `log`), so the `logsumexp` rule never fires and `log∘(convex)` is legitimately non-DCP. Fixed by defining `LogExpFunctions.logsumexp(x::Symbolics.Arr)` to build an unevaluated `logsumexp` term via `SymbolicUtils.term` (the same pattern as the package's `matrix_atom`; dispatching on the concrete `Arr` is strictly more specific than Symbolics' vector method, so it extends rather than overwrites, and emits no scalar `BasicSymbolic` method).
2. **Wrong domain.** The rule was registered for `array_domain(RealLine(), 2)` (dimension 2), wrong for a 1-D vector. Changed to the dimension-agnostic `array_domain(RealLine())`, matching the sibling `maximum`/`minimum` reductions. Docs row updated.

`logsumexp(z)` → `Convex`. Test asserts both the curvature and — load-bearing — that `operation(logsumexp(z))` stays `logsumexp` (fails before, passes after). Full suite passes.

Part of #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
