### PR TITLE
Allow SciMLTesting v2 in QA compat

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ SymbolicAnalysis = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.1"
-SciMLTesting = "1"
+SciMLTesting = "1, 2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Allow `SciMLTesting` v2.1+ in the QA environment.
- Keep the existing v1 allowance so this is a compat expansion only.

This is a split QA-only follow-up to #130, which updates `test/Project.toml` but not `test/qa/Project.toml`.

## Validation

- `git diff --check`
- Runic check on `test/qa/Project.toml`.
- TOML parse/assert confirmed `test/qa/Project.toml` has `SciMLTesting = "1, 2.1"`.
- QA env `Pkg.resolve()` selected `SciMLTesting v2.2.0` and `test/qa/qa.jl` passed: 13/13.
