### PR TITLE
Enable rendered public docs QA

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,9 +6,6 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SymbolicAnalysis = "4297ee4d-0239-47d8-ba5d-195ecdf594fe"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-SymbolicAnalysis = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -21,6 +21,7 @@ run_qa(
     SymbolicAnalysis;
     Aqua = Aqua,
     JET = JET,
+    api_docs_kwargs = (; rendered = true),
     jet = true,
     aqua_kwargs = (; piracies = (; treat_as_own = SYMBOLIC_OWN)),
     jet_kwargs = (; target_modules = (SymbolicAnalysis,), mode = :typo),


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- enable SciMLTesting rendered public API docs QA
- remove the QA `[sources]` path override; validation develops the local package explicitly

## Validation
- `git diff --check`
- `Runic.main(["--check", "src", "test", "docs/make.jl"])` on Julia +1.10
- direct QA via `julia +1.10 --project=test/qa ... include("test/qa/qa.jl")`: passed, `Quality Assurance | 14/14`
- docs build on Julia +1.10: passed with existing local deployment/logo/favicon warnings only
- full `Pkg.test()` on Julia +1.10: passed

No `[sources]` or path source overrides remain in the QA project.