### PR TITLE
Bump SymbolicAnalysis to v0.4.0 for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicAnalysis"
 uuid = "4297ee4d-0239-47d8-ba5d-195ecdf594fe"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com>", "Shashi Gowda <gowda@mit.edu>"]
-version = "0.3.9"
+version = "0.4.0"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"


### PR DESCRIPTION
Releases unreleased changes on master: DCP rules for eigmax/eigmin (#126) and de-piracy of the analysis path (#125).

**Semver note:** bumped 0.3.9 → 0.4.0 (minor) rather than patch because #126 adds new DCP-rule capability and #125 removes previously-pirated methods (potentially breaking for downstream relying on them). Please confirm 0.4.0 is the intended level.

Detected by comparing the `git-tree-sha1` of the latest live registered version in General against the `src` subtree on the default branch. Only the `version` field in `Project.toml` is changed. **No local test run** — CI on this PR is the check. Please ignore until reviewed by @ChrisRackauckas.