### PR TITLE
compat: raise SciMLTesting floor to 2.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,7 @@ StatsBase = "0.34"
 SymbolicUtils = "4.45"
 Symbolics = "7.31.2"
 TermInterface = "2"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -34,4 +34,8 @@ StatsBase = "0.34"
 SymbolicUtils = "4.45"
 Symbolics = "7.31.2"
 TermInterface = "2"
+SciMLTesting = "2.4"
 julia = "1.10"
+
+[extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"


### PR DESCRIPTION
This is a mechanical compat-only PR. Raise every affected root/sublibrary SciMLTesting compat entry from 2.1 to 2.10 so the repository uses the strict SciMLTesting QA defaults. No source, test behavior, or documentation changes are included. Please ignore this draft until reviewed by @ChrisRackauckas. Local git diff --check and typos checks pass.