### PR TITLE
Bump versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicAnalysis"
 uuid = "4297ee4d-0239-47d8-ba5d-195ecdf594fe"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com>", "Shashi Gowda <gowda@mit.edu>"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"


### PR DESCRIPTION
Bumps the version(s) below so the src changes already merged to `main` can be registered in the General registry.

- SymbolicAnalysis: 0.5.0 -> 0.5.1

No code changes — version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
