### PR TITLE
Interactive DCP atoms table for docs (+ link/Sign-column fixes)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "/home/langestefan/dev/projects/2026/SymbolicAnalysis.jl"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "julia.environmentPath": "/home/langestefan/dev/projects/2026/SymbolicAnalysis.jl"
-}

--- a/docs/src/.vitepress/theme/components/AtomTable.vue
+++ b/docs/src/.vitepress/theme/components/AtomTable.vue
@@ -355,30 +355,37 @@ function parseMonotonicity(raw: string): MonoPart[] {
               :class="['col-' + col.key, { sortable: col.sortable !== false, 'has-filter': col.filterable }]"
             >
               <div class="th-content">
-                <!-- Column label — click to sort -->
-                <span
-                  class="th-label"
-                  :class="{ clickable: col.sortable !== false }"
-                  @click="col.sortable !== false && toggleSort(col.key)"
-                >
-                  {{ col.label }}
-                  <span v-if="col.sortable !== false" class="sort-indicator">
-                    {{ sortIndicator(col.key) }}
-                  </span>
-                </span>
+                <!-- Column label -->
+                <span class="th-label">{{ col.label }}</span>
 
-                <!-- Filter toggle button (only for filterable columns) -->
-                <button
-                  v-if="col.filterable"
-                  class="filter-toggle-btn"
-                  :class="{ active: isFilterActive(col.key), open: openFilterKey === col.key }"
-                  :title="`Filter by ${col.label}`"
-                  @click="toggleFilterDropdown(col.key, $event)"
-                >
-                  <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor">
-                    <path d="M1 2h14l-5 6v5l-4 2V8L1 2z"/>
-                  </svg>
-                </button>
+                <!-- Sort & filter controls row -->
+                <div class="th-controls" v-if="col.sortable !== false || col.filterable">
+                  <!-- Sort button -->
+                  <button
+                    v-if="col.sortable !== false"
+                    class="sort-btn"
+                    :title="`Sort by ${col.label}`"
+                    @click="toggleSort(col.key)"
+                  >
+                    <svg viewBox="0 0 16 16" width="11" height="11" fill="currentColor">
+                      <path d="M3 7l5-5 5 5H3z" :opacity="sortKey === col.key && sortDir === 'asc' ? 1 : 0.3"/>
+                      <path d="M3 9l5 5 5-5H3z" :opacity="sortKey === col.key && sortDir === 'desc' ? 1 : 0.3"/>
+                    </svg>
+                  </button>
+
+                  <!-- Filter toggle button -->
+                  <button
+                    v-if="col.filterable"
+                    class="filter-toggle-btn"
+                    :class="{ active: isFilterActive(col.key), open: openFilterKey === col.key }"
+                    :title="`Filter by ${col.label}`"
+                    @click="toggleFilterDropdown(col.key, $event)"
+                  >
+                    <svg viewBox="0 0 16 16" width="11" height="11" fill="currentColor">
+                      <path d="M1 2h14l-5 6v5l-4 2V8L1 2z"/>
+                    </svg>
+                  </button>
+                </div>
               </div>
 
               <!-- Dropdown panel (positioned absolutely below the header) -->
@@ -565,6 +572,7 @@ function parseMonotonicity(raw: string): MonoPart[] {
 .atom-table td {
   padding: 0.35rem 0.5rem;
   text-align: left;
+  vertical-align: top;
   border-bottom: 1px solid var(--vp-c-divider);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -589,29 +597,42 @@ function parseMonotonicity(raw: string): MonoPart[] {
 
 /* ---- Header content layout ---- */
 .th-content {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
 }
 
 .th-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.2rem;
-}
-.th-label.clickable {
-  cursor: pointer;
-}
-.th-label.clickable:hover {
-  color: var(--vp-c-brand-1);
+  font-weight: 600;
 }
 
-.sort-indicator {
-  font-size: 0.625rem;
-  opacity: 0.4;
+/* Controls row below label */
+.th-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
 }
-.th-label.clickable:hover .sort-indicator {
-  opacity: 1;
+
+/* Sort button */
+.sort-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--vp-c-text-3);
+  cursor: pointer;
+  transition: all 0.15s;
+  flex-shrink: 0;
+}
+.sort-btn:hover {
+  background: var(--vp-c-default-soft);
+  color: var(--vp-c-text-1);
 }
 
 /* ---- Filter toggle button (funnel icon in header) ---- */
@@ -629,7 +650,6 @@ function parseMonotonicity(raw: string): MonoPart[] {
   cursor: pointer;
   transition: all 0.15s;
   flex-shrink: 0;
-  margin-left: 2px;
 }
 .filter-toggle-btn:hover {
   background: var(--vp-c-default-soft);
@@ -764,10 +784,14 @@ function parseMonotonicity(raw: string): MonoPart[] {
   word-break: break-word;
 }
 .col-atom,
-.col-meaning,
+.col-meaning {
+  white-space: normal;
+  word-break: break-word;
+}
 .col-monotonicity {
   white-space: normal;
   word-break: break-word;
+  width: 1%;
 }
 .math-cell {
   font-size: inherit;
@@ -797,7 +821,7 @@ function parseMonotonicity(raw: string): MonoPart[] {
 
 /* ---- Monotonicity cell ---- */
 .mono-cell {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 0.15rem;
@@ -807,7 +831,7 @@ function parseMonotonicity(raw: string): MonoPart[] {
   display: inline-flex;
   align-items: center;
   gap: 0.2rem;
-  white-space: nowrap;
+  white-space: normal;
   font-size: inherit;
 }
 

--- a/docs/src/.vitepress/theme/components/AtomTable.vue
+++ b/docs/src/.vitepress/theme/components/AtomTable.vue
@@ -106,6 +106,7 @@ const docLinks: Record<string, string> = {
   'tv (matrix)': 'SymbolicAnalysis.tv-Tuple{AbstractVector{<:AbstractMatrix}}',
   'huber': 'SymbolicAnalysis.huber',
   'lognormcdf': 'SymbolicAnalysis.lognormcdf-Tuple{Real}',
+  'rel_entr': 'SymbolicAnalysis.rel_entr-Tuple{Real, Real}',
   // DGCP SPD atoms
   'conjugation': 'SymbolicAnalysis.conjugation-Tuple{Any, Any}',
   'scalar_mat': 'SymbolicAnalysis.scalar_mat',
@@ -124,9 +125,16 @@ const docLinks: Record<string, string> = {
   'lorentz_transform': 'SymbolicAnalysis.lorentz_transform-Tuple{AbstractMatrix, AbstractVector}',
 }
 
-function getDocLink(atomName: string): string | null {
+function getDocLink(atomName: string, row?: Record<string, string>): string | null {
+  // First check for external doc URL from JSON data (external packages)
+  if (row?.docUrl) return row.docUrl
+  // Then check for internal docstring link (SymbolicAnalysis functions)
   const anchor = docLinks[atomName]
   return anchor ? `./functions.html#${anchor}` : null
+}
+
+function isExternalLink(row?: Record<string, string>): boolean {
+  return !!row?.docUrl
 }
 
 /* ------------------------------------------------------------------ */
@@ -489,8 +497,20 @@ function parseMonotonicity(raw: string): MonoPart[] {
               </template>
               <!-- Atom name (with optional docstring link) -->
               <template v-else-if="col.key === nameKey">
-                <a v-if="getDocLink(row[col.key])" :href="getDocLink(row[col.key])!" class="atom-link">
+                <a
+                  v-if="getDocLink(row[col.key], row)"
+                  :href="getDocLink(row[col.key], row)!"
+                  class="atom-link"
+                  :class="{ 'external-link': isExternalLink(row) }"
+                  :target="isExternalLink(row) ? '_blank' : undefined"
+                  :rel="isExternalLink(row) ? 'noopener noreferrer' : undefined"
+                >
                   <code class="atom-name">{{ row[col.key] }}</code>
+                  <svg v-if="isExternalLink(row)" class="external-icon" viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                    <polyline points="15 3 21 3 21 9" />
+                    <line x1="10" y1="14" x2="21" y2="3" />
+                  </svg>
                 </a>
                 <code v-else class="atom-name">{{ row[col.key] }}</code>
               </template>
@@ -775,6 +795,16 @@ function parseMonotonicity(raw: string): MonoPart[] {
   text-decoration: underline;
   background: var(--vp-c-brand-soft);
   color: var(--vp-c-brand-2, var(--vp-c-brand-1));
+}
+.atom-link .external-icon {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 3px;
+  opacity: 0.5;
+  transition: opacity 0.15s;
+}
+.atom-link:hover .external-icon {
+  opacity: 0.85;
 }
 
 /* ---- Math / domain cell ---- */

--- a/docs/src/.vitepress/theme/components/AtomTable.vue
+++ b/docs/src/.vitepress/theme/components/AtomTable.vue
@@ -1,0 +1,855 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import MarkdownIt from 'markdown-it'
+import mathjax3 from 'markdown-it-mathjax3'
+
+const md = MarkdownIt({ html: true }).use(mathjax3)
+
+/* ------------------------------------------------------------------ */
+/*  Built-in data & column configs (no external props needed)          */
+/* ------------------------------------------------------------------ */
+
+import dcpAtoms from '../../../data/dcp_atoms.json'
+import dcpPowerAtoms from '../../../data/dcp_power_atoms.json'
+import dgcpSpdAtoms from '../../../data/dgcp_spd_atoms.json'
+import dgcpLorentzAtoms from '../../../data/dgcp_lorentz_atoms.json'
+
+interface ColumnDef {
+  key: string
+  label: string
+  filterable?: boolean
+  sortable?: boolean
+  icon?: boolean
+  monoIcon?: boolean
+  math?: boolean
+}
+
+const dataSets: Record<string, Record<string, string>[]> = {
+  dcp: dcpAtoms as Record<string, string>[],
+  'dcp-power': dcpPowerAtoms as Record<string, string>[],
+  'dgcp-spd': dgcpSpdAtoms as Record<string, string>[],
+  'dgcp-lorentz': dgcpLorentzAtoms as Record<string, string>[],
+}
+
+const columnConfigs: Record<string, ColumnDef[]> = {
+  dcp: [
+    { key: 'atom',         label: 'Atom',         sortable: true,  filterable: false },
+    { key: 'meaning',      label: 'Meaning',      sortable: false, filterable: false, math: true },
+    { key: 'domain',       label: 'Domain',       sortable: false, filterable: false, math: true },
+    { key: 'curvature',    label: 'Curvature',    sortable: true,  filterable: true, icon: true },
+    { key: 'monotonicity', label: 'Monotonicity', sortable: true,  filterable: true, monoIcon: true },
+  ],
+  'dcp-power': [
+    { key: 'condition',    label: 'Condition',    sortable: false, filterable: false, math: true },
+    { key: 'meaning',      label: 'Meaning',      sortable: false, filterable: false, math: true },
+    { key: 'domain',       label: 'Domain',       sortable: false, filterable: false, math: true },
+    { key: 'curvature',    label: 'Curvature',    sortable: true,  filterable: true, icon: true },
+    { key: 'monotonicity', label: 'Monotonicity', sortable: true,  filterable: true, monoIcon: true },
+  ],
+  'dgcp-spd': [
+    { key: 'atom',         label: 'Atom',         sortable: true,  filterable: false },
+    { key: 'meaning',      label: 'Meaning',      sortable: false, filterable: false, math: true },
+    { key: 'curvature',    label: 'G-Curvature',  sortable: true,  filterable: true, icon: true },
+    { key: 'monotonicity', label: 'Monotonicity', sortable: true,  filterable: true, monoIcon: true },
+  ],
+  'dgcp-lorentz': [
+    { key: 'atom',         label: 'Atom',         sortable: true,  filterable: false },
+    { key: 'meaning',      label: 'Meaning',      sortable: false, filterable: false, math: true },
+    { key: 'curvature',    label: 'G-Curvature',  sortable: true,  filterable: true, icon: true },
+    { key: 'monotonicity', label: 'Monotonicity', sortable: true,  filterable: true, monoIcon: true },
+  ],
+}
+
+/* ------------------------------------------------------------------ */
+/*  Props — only need a source key string                              */
+/* ------------------------------------------------------------------ */
+
+const props = defineProps({
+  src: { type: String, required: true },
+})
+
+const data = computed(() => dataSets[props.src] ?? [])
+const columns = computed(() => columnConfigs[props.src] ?? [])
+
+/* ------------------------------------------------------------------ */
+/*  LaTeX rendering via MathJax (markdown-it-mathjax3)                 */
+/* ------------------------------------------------------------------ */
+
+function renderLatex(tex: string): string {
+  if (!tex) return ''
+  try {
+    return md.render(`$${tex}$`).replace(/^<p>|<\/p>\s*$/g, '')
+  } catch {
+    return tex
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Docstring links — map atom name → functions page anchor            */
+/* ------------------------------------------------------------------ */
+
+const docLinks: Record<string, string> = {
+  // DCP atoms
+  'dotsort': 'SymbolicAnalysis.dotsort-Tuple{AbstractVector, AbstractVector}',
+  'invprod': 'SymbolicAnalysis.invprod-Tuple{AbstractVector}',
+  'eigsummax': 'SymbolicAnalysis.eigsummax-Tuple{LinearAlgebra.Symmetric, Int64}',
+  'eigsummin': 'SymbolicAnalysis.eigsummin-Tuple{LinearAlgebra.Symmetric, Int64}',
+  'matrix_frac': 'SymbolicAnalysis.matrix_frac-Tuple{AbstractVector, AbstractMatrix}',
+  'perspective(f, x, s)': 'SymbolicAnalysis.perspective-Tuple{Function, Any, Real}',
+  'quad_form': 'SymbolicAnalysis.quad_form-Tuple{AbstractVector, AbstractMatrix}',
+  'quad_over_lin (array)': 'SymbolicAnalysis.quad_over_lin-Tuple{Real, Real}',
+  'quad_over_lin (scalar)': 'SymbolicAnalysis.quad_over_lin-Tuple{Real, Real}',
+  'sum_largest': 'SymbolicAnalysis.sum_largest-Tuple{AbstractMatrix, Integer}',
+  'sum_smallest': 'SymbolicAnalysis.sum_smallest-Tuple{AbstractMatrix, Integer}',
+  'trinv': 'SymbolicAnalysis.trinv-Tuple{AbstractMatrix}',
+  'tv (vector)': 'SymbolicAnalysis.tv-Tuple{AbstractVector{<:Real}}',
+  'tv (matrix)': 'SymbolicAnalysis.tv-Tuple{AbstractVector{<:AbstractMatrix}}',
+  'huber': 'SymbolicAnalysis.huber',
+  'lognormcdf': 'SymbolicAnalysis.lognormcdf-Tuple{Real}',
+  // DGCP SPD atoms
+  'conjugation': 'SymbolicAnalysis.conjugation-Tuple{Any, Any}',
+  'scalar_mat': 'SymbolicAnalysis.scalar_mat',
+  'sdivergence': 'SymbolicAnalysis.sdivergence-Tuple{Any, Any}',
+  // quad_form already covered by DCP entry above
+  'log_quad_form': 'SymbolicAnalysis.log_quad_form-Tuple{Vector{<:Number}, Matrix}',
+  'schatten_norm': 'SymbolicAnalysis.schatten_norm',
+  'sum_log_eigmax': 'SymbolicAnalysis.sum_log_eigmax-Tuple{Function, AbstractMatrix, Int64}',
+  'affine_map': 'SymbolicAnalysis.affine_map-Tuple{typeofSymbolicAnalysis.conjugation, Matrix, Matrix, Matrix}',
+  'hadamard_product': 'SymbolicAnalysis.hadamard_product-Tuple{AbstractMatrix, AbstractMatrix}',
+  // DGCP Lorentz atoms
+  'lorentz_log_barrier': 'SymbolicAnalysis.lorentz_log_barrier-Tuple{AbstractVector}',
+  'lorentz_homogeneous_quadratic': 'SymbolicAnalysis.lorentz_homogeneous_quadratic-Tuple{AbstractMatrix, AbstractVector}',
+  'lorentz_homogeneous_diagonal': 'SymbolicAnalysis.lorentz_homogeneous_diagonal-Tuple{AbstractVector, AbstractVector}',
+  'lorentz_least_squares': 'SymbolicAnalysis.lorentz_least_squares-Tuple{AbstractMatrix, AbstractVector, AbstractVector}',
+  'lorentz_transform': 'SymbolicAnalysis.lorentz_transform-Tuple{AbstractMatrix, AbstractVector}',
+}
+
+function getDocLink(atomName: string): string | null {
+  const anchor = docLinks[atomName]
+  return anchor ? `./functions.html#${anchor}` : null
+}
+
+/* ------------------------------------------------------------------ */
+/*  Search & filter state                                              */
+/* ------------------------------------------------------------------ */
+
+const searchQuery = ref('')
+
+// Multi-select: each filterable column has a Set of selected values
+// Empty set = show all (no filter active)
+const selectedFilters = ref<Record<string, Set<string>>>({})
+
+function toggleFilterValue(colKey: string, value: string) {
+  if (!selectedFilters.value[colKey]) {
+    selectedFilters.value[colKey] = new Set()
+  }
+  const s = selectedFilters.value[colKey]
+  if (s.has(value)) {
+    s.delete(value)
+  } else {
+    s.add(value)
+  }
+  // Force reactivity
+  selectedFilters.value = { ...selectedFilters.value }
+}
+
+function clearFilter(colKey: string) {
+  selectedFilters.value[colKey] = new Set()
+  selectedFilters.value = { ...selectedFilters.value }
+}
+
+function isFilterActive(colKey: string): boolean {
+  const s = selectedFilters.value[colKey]
+  return !!s && s.size > 0
+}
+
+// Distinct options per filterable column (derived from data)
+const filterOptions = computed(() => {
+  const opts: Record<string, string[]> = {}
+  for (const col of columns.value) {
+    if (!col.filterable) continue
+    const unique = [...new Set(data.value.map(r => r[col.key]))]
+      .filter(Boolean)
+      .sort()
+    opts[col.key] = unique
+  }
+  return opts
+})
+
+/* ------------------------------------------------------------------ */
+/*  Column header filter dropdown state                                */
+/* ------------------------------------------------------------------ */
+
+const openFilterKey = ref<string | null>(null)
+
+function toggleFilterDropdown(colKey: string, event: MouseEvent) {
+  event.stopPropagation()
+  openFilterKey.value = openFilterKey.value === colKey ? null : colKey
+}
+
+function closeAllDropdowns() {
+  openFilterKey.value = null
+}
+
+// Close dropdown when clicking outside
+function handleDocumentClick(e: MouseEvent) {
+  const target = e.target as HTMLElement
+  if (!target.closest('.header-filter-dropdown') && !target.closest('.filter-toggle-btn')) {
+    closeAllDropdowns()
+  }
+}
+
+onMounted(() => document.addEventListener('click', handleDocumentClick))
+onUnmounted(() => document.removeEventListener('click', handleDocumentClick))
+
+/* ------------------------------------------------------------------ */
+/*  Sort state                                                         */
+/* ------------------------------------------------------------------ */
+
+const sortKey = ref<string | null>(null)
+const sortDir = ref<'asc' | 'desc'>('asc')
+
+function toggleSort(key: string) {
+  if (sortKey.value === key) {
+    if (sortDir.value === 'asc') sortDir.value = 'desc'
+    else { sortKey.value = null; sortDir.value = 'asc' }
+  } else {
+    sortKey.value = key
+    sortDir.value = 'asc'
+  }
+}
+
+function sortIndicator(key: string) {
+  if (sortKey.value !== key) return '⇅'
+  return sortDir.value === 'asc' ? '↑' : '↓'
+}
+
+/* ------------------------------------------------------------------ */
+/*  Filtered + sorted rows                                             */
+/* ------------------------------------------------------------------ */
+
+const nameKey = computed(() => {
+  const first = columns.value[0]
+  return first ? first.key : 'atom'
+})
+
+const filteredRows = computed(() => {
+  let rows = data.value
+
+  // Text search
+  if (searchQuery.value.trim()) {
+    const q = searchQuery.value.trim().toLowerCase()
+    rows = rows.filter(r => (r[nameKey.value] ?? '').toLowerCase().includes(q))
+  }
+
+  // Multi-select filters
+  for (const [key, selected] of Object.entries(selectedFilters.value)) {
+    if (selected.size > 0) {
+      rows = rows.filter(r => selected.has(r[key]))
+    }
+  }
+
+  // Sort
+  if (sortKey.value) {
+    const k = sortKey.value
+    const dir = sortDir.value === 'asc' ? 1 : -1
+    rows = [...rows].sort((a, b) => {
+      const va = (a[k] ?? '').toLowerCase()
+      const vb = (b[k] ?? '').toLowerCase()
+      return va < vb ? -dir : va > vb ? dir : 0
+    })
+  }
+
+  return rows
+})
+
+/* ------------------------------------------------------------------ */
+/*  Curvature → icon mapping                                           */
+/* ------------------------------------------------------------------ */
+
+const curvatureIcons: Record<string, { color: string; darkColor: string; path: string; label: string }> = {
+  convex:   { color: '#4063D8', darkColor: '#6B8BFF', path: 'M 4 2 Q 12 22 20 2',  label: 'Convex'   },
+  concave:  { color: '#389826', darkColor: '#5BC848', path: 'M 4 20 Q 12 0 20 20', label: 'Concave'  },
+  affine:   { color: '#CB3C33', darkColor: '#FF6B61', path: 'M 4 20 L 20 4',       label: 'Affine'   },
+  gconvex:  { color: '#9558B2', darkColor: '#B87FD4', path: 'M 4 2 Q 12 22 20 2',  label: 'GConvex'  },
+  glinear:  { color: '#9558B2', darkColor: '#B87FD4', path: 'M 4 20 L 20 4',       label: 'GLinear'  },
+  gconcave: { color: '#9558B2', darkColor: '#B87FD4', path: 'M 4 20 Q 12 0 20 20', label: 'GConcave' },
+}
+
+function curvatureKey(raw: string): string | null {
+  if (!raw) return null
+  const l = raw.toLowerCase().replace(/\s+/g, '')
+  if (l === 'gconvex') return 'gconvex'
+  if (l === 'glinear') return 'glinear'
+  if (l === 'gconcave') return 'gconcave'
+  if (l === 'convex') return 'convex'
+  if (l === 'concave') return 'concave'
+  if (l === 'affine') return 'affine'
+  return null
+}
+
+/* ------------------------------------------------------------------ */
+/*  Monotonicity → icon mapping                                        */
+/* ------------------------------------------------------------------ */
+
+const monotonicityIcons: Record<string, { color: string; darkColor: string; path: string; arrowPath?: string; label: string; dashed: boolean }> = {
+  increasing:             { color: '#389826', darkColor: '#5BC848', path: 'M 5 19 L 19 5',  arrowPath: 'M 13 5 L 19 5 L 19 11',    label: 'Increasing',     dashed: false },
+  decreasing:             { color: '#CB3C33', darkColor: '#FF6B61', path: 'M 5 5 L 19 19',  arrowPath: 'M 13 19 L 19 19 L 19 13',  label: 'Decreasing',     dashed: false },
+  anymono:                { color: '#888888', darkColor: '#AAAAAA', path: 'M 4 12 L 20 12',                                          label: 'Non-monotonic',  dashed: false },
+  increasing_if_positive: { color: '#389826', darkColor: '#5BC848', path: 'M 5 19 L 19 5',  arrowPath: 'M 13 5 L 19 5 L 19 11',    label: 'Incr. if pos.',  dashed: true  },
+  gincreasing:            { color: '#9558B2', darkColor: '#B87FD4', path: 'M 5 19 L 19 5',  arrowPath: 'M 13 5 L 19 5 L 19 11',    label: 'GIncreasing',    dashed: true  },
+  gdecreasing:            { color: '#9558B2', darkColor: '#B87FD4', path: 'M 5 5 L 19 19',  arrowPath: 'M 13 19 L 19 19 L 19 13',  label: 'GDecreasing',    dashed: true  },
+  ganymono:               { color: '#9558B2', darkColor: '#B87FD4', path: 'M 4 12 L 20 12',                                          label: 'GAnyMono',       dashed: true  },
+}
+
+function monoKey(raw: string): string | null {
+  if (!raw) return null
+  const l = raw.toLowerCase().replace(/\s+/g, '')
+  if (l === 'increasing') return 'increasing'
+  if (l === 'decreasing') return 'decreasing'
+  if (l === 'anymono' || l === 'any') return 'anymono'
+  if (l.startsWith('increasing_if_positive') || l.startsWith('increasingifpositive') || l.startsWith('incr.ifpos.')) return 'increasing_if_positive'
+  if (l === 'gincreasing') return 'gincreasing'
+  if (l === 'gdecreasing') return 'gdecreasing'
+  if (l === 'ganymono' || l === 'gany') return 'ganymono'
+  return null
+}
+
+interface MonoPart {
+  key: string | null
+  text: string
+}
+
+function parseMonotonicity(raw: string): MonoPart[] {
+  if (!raw || raw === '—') return [{ key: null, text: '—' }]
+  const tupleMatch = raw.match(/^\((.+)\)$/)
+  if (tupleMatch) {
+    const inner = tupleMatch[1]
+    const parts: string[] = []
+    let depth = 0, start = 0
+    for (let i = 0; i < inner.length; i++) {
+      if (inner[i] === '(') depth++
+      else if (inner[i] === ')') depth--
+      else if (inner[i] === ',' && depth === 0) {
+        parts.push(inner.substring(start, i).trim())
+        start = i + 1
+      }
+    }
+    parts.push(inner.substring(start).trim())
+    return parts.map(p => ({ key: monoKey(p), text: p }))
+  }
+  return [{ key: monoKey(raw), text: raw }]
+}
+</script>
+
+<template>
+  <div :class="['atom-table-wrapper', src]">
+    <!-- Table -->
+    <div class="atom-table-scroll">
+      <table class="atom-table">
+        <thead>
+          <tr>
+            <th
+              v-for="col in columns"
+              :key="col.key"
+              :class="['col-' + col.key, { sortable: col.sortable !== false, 'has-filter': col.filterable }]"
+            >
+              <div class="th-content">
+                <!-- Column label — click to sort -->
+                <span
+                  class="th-label"
+                  :class="{ clickable: col.sortable !== false }"
+                  @click="col.sortable !== false && toggleSort(col.key)"
+                >
+                  {{ col.label }}
+                  <span v-if="col.sortable !== false" class="sort-indicator">
+                    {{ sortIndicator(col.key) }}
+                  </span>
+                </span>
+
+                <!-- Filter toggle button (only for filterable columns) -->
+                <button
+                  v-if="col.filterable"
+                  class="filter-toggle-btn"
+                  :class="{ active: isFilterActive(col.key), open: openFilterKey === col.key }"
+                  :title="`Filter by ${col.label}`"
+                  @click="toggleFilterDropdown(col.key, $event)"
+                >
+                  <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor">
+                    <path d="M1 2h14l-5 6v5l-4 2V8L1 2z"/>
+                  </svg>
+                </button>
+              </div>
+
+              <!-- Dropdown panel (positioned absolutely below the header) -->
+              <div
+                v-if="col.filterable && openFilterKey === col.key"
+                class="header-filter-dropdown"
+                @click.stop
+              >
+                <div class="filter-dropdown-header">
+                  <span class="filter-dropdown-title">Filter {{ col.label }}</span>
+                  <button
+                    v-if="isFilterActive(col.key)"
+                    class="filter-clear-btn"
+                    @click="clearFilter(col.key)"
+                  >Clear</button>
+                </div>
+                <div class="filter-options">
+                  <label
+                    v-for="opt in filterOptions[col.key]"
+                    :key="opt"
+                    class="filter-option"
+                  >
+                    <input
+                      type="checkbox"
+                      :checked="selectedFilters[col.key]?.has(opt)"
+                      @change="toggleFilterValue(col.key, opt)"
+                    />
+                    <span class="filter-option-text">{{ opt }}</span>
+                  </label>
+                </div>
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(row, idx) in filteredRows" :key="idx">
+            <td v-for="col in columns" :key="col.key" :class="['col-' + col.key]">
+              <!-- Curvature cell with icon -->
+              <template v-if="col.icon && curvatureKey(row[col.key])">
+                <span class="curvature-cell">
+                  <svg
+                    class="curvature-icon"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true"
+                  >
+                    <path
+                      :d="curvatureIcons[curvatureKey(row[col.key])!].path"
+                      fill="none"
+                      :stroke="curvatureIcons[curvatureKey(row[col.key])!].color"
+                      stroke-width="2.5"
+                      stroke-linecap="round"
+                      :stroke-dasharray="curvatureKey(row[col.key])!.startsWith('g') ? '4 3' : 'none'"
+                      class="curvature-path"
+                    />
+                  </svg>
+                  <span>{{ row[col.key] }}</span>
+                </span>
+              </template>
+              <!-- Monotonicity cell with icon(s) -->
+              <template v-else-if="col.monoIcon">
+                <span class="mono-cell">
+                  <template v-for="(part, pidx) in parseMonotonicity(row[col.key])" :key="pidx">
+                    <span v-if="pidx > 0" class="mono-sep">, </span>
+                    <span class="mono-part">
+                      <svg
+                        v-if="part.key && monotonicityIcons[part.key]"
+                        class="mono-icon"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                        aria-hidden="true"
+                      >
+                        <path
+                          :d="monotonicityIcons[part.key].path"
+                          fill="none"
+                          :stroke="monotonicityIcons[part.key].color"
+                          stroke-width="2.5"
+                          stroke-linecap="round"
+                          :stroke-dasharray="monotonicityIcons[part.key].dashed ? '4 3' : 'none'"
+                          class="mono-path"
+                        />
+                        <path
+                          v-if="monotonicityIcons[part.key].arrowPath"
+                          :d="monotonicityIcons[part.key].arrowPath"
+                          fill="none"
+                          :stroke="monotonicityIcons[part.key].color"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          class="mono-path"
+                        />
+                      </svg>
+                      <span>{{ part.text }}</span>
+                    </span>
+                  </template>
+                </span>
+              </template>
+              <!-- Math cell (domain / condition rendered with KaTeX) -->
+              <template v-else-if="col.math">
+                <span class="math-cell" v-html="renderLatex(row[col.key])"></span>
+              </template>
+              <!-- Atom name (with optional docstring link) -->
+              <template v-else-if="col.key === nameKey">
+                <a v-if="getDocLink(row[col.key])" :href="getDocLink(row[col.key])!" class="atom-link">
+                  <code class="atom-name">{{ row[col.key] }}</code>
+                </a>
+                <code v-else class="atom-name">{{ row[col.key] }}</code>
+              </template>
+              <!-- Normal cell -->
+              <template v-else>
+                <span>{{ row[col.key] }}</span>
+              </template>
+            </td>
+          </tr>
+          <tr v-if="filteredRows.length === 0">
+            <td :colspan="columns.length" class="no-results">
+              No atoms match the current filters.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* ---- Wrapper ---- */
+.atom-table-wrapper {
+  max-width: 100%;
+  overflow: hidden;
+}
+
+/* ---- Filter bar (search only) ---- */
+.atom-table-filters {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.atom-search {
+  flex: 0 1 220px;
+  min-width: 120px;
+  max-width: 220px;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  font-size: 0.8125rem;
+  outline: none;
+  transition: border-color 0.2s;
+}
+.atom-search:focus {
+  border-color: var(--vp-c-brand-1);
+}
+.atom-search::placeholder {
+  color: var(--vp-c-text-3);
+}
+
+/* ---- Count (inline) ---- */
+.atom-table-count {
+  font-size: 0.75rem;
+  color: var(--vp-c-text-3);
+  white-space: nowrap;
+}
+
+/* ---- Table ---- */
+.atom-table-scroll {
+  overflow-x: auto;
+  margin: 0 -0.5rem;
+  padding: 0 0.5rem;
+}
+
+.atom-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  table-layout: auto;
+}
+
+.atom-table th,
+.atom-table td {
+  padding: 0.35rem 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid var(--vp-c-divider);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.atom-table th {
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: var(--vp-c-text-2);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  background: var(--vp-c-bg-soft);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  user-select: none;
+  white-space: nowrap;
+  /* Allow dropdown to overflow */
+  overflow: visible;
+  position: relative;
+}
+
+/* ---- Header content layout ---- */
+.th-content {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.th-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+.th-label.clickable {
+  cursor: pointer;
+}
+.th-label.clickable:hover {
+  color: var(--vp-c-brand-1);
+}
+
+.sort-indicator {
+  font-size: 0.625rem;
+  opacity: 0.4;
+}
+.th-label.clickable:hover .sort-indicator {
+  opacity: 1;
+}
+
+/* ---- Filter toggle button (funnel icon in header) ---- */
+.filter-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--vp-c-text-3);
+  cursor: pointer;
+  transition: all 0.15s;
+  flex-shrink: 0;
+  margin-left: 2px;
+}
+.filter-toggle-btn:hover {
+  background: var(--vp-c-default-soft);
+  color: var(--vp-c-text-1);
+}
+.filter-toggle-btn.active {
+  color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+}
+.filter-toggle-btn.open {
+  color: var(--vp-c-brand-1);
+}
+
+/* ---- Header filter dropdown panel ---- */
+.header-filter-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  min-width: 140px;
+  max-width: 200px;
+  background: var(--vp-c-bg-elv);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  z-index: 100;
+  padding: 0.4rem 0;
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: 400;
+}
+
+.filter-dropdown-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.2rem 0.6rem 0.35rem;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.filter-dropdown-title {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--vp-c-text-2);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.filter-clear-btn {
+  font-size: 0.6875rem;
+  color: var(--vp-c-brand-1);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  font-weight: 500;
+}
+.filter-clear-btn:hover {
+  text-decoration: underline;
+}
+
+/* ---- Checkbox options ---- */
+.filter-options {
+  padding: 0.3rem 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.filter-option {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.6rem;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--vp-c-text-1);
+  transition: background 0.1s;
+  white-space: nowrap;
+}
+.filter-option:hover {
+  background: var(--vp-c-default-soft);
+}
+
+.filter-option input[type="checkbox"] {
+  width: 14px;
+  height: 14px;
+  margin: 0;
+  accent-color: var(--vp-c-brand-1);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.filter-option-text {
+  line-height: 1.3;
+}
+
+/* ---- Body ---- */
+.atom-table tbody tr:hover {
+  background: var(--vp-c-bg-soft);
+}
+
+/* ---- Atom name ---- */
+.atom-name {
+  font-size: inherit;
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+  background: var(--vp-c-mute);
+  color: var(--vp-c-text-1);
+  font-family: inherit;
+  white-space: nowrap;
+}
+
+/* ---- Atom link ---- */
+.atom-link {
+  text-decoration: none;
+  color: var(--vp-c-brand-1);
+}
+.atom-link .atom-name {
+  color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+  cursor: pointer;
+}
+.atom-link:hover .atom-name {
+  text-decoration: underline;
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-2, var(--vp-c-brand-1));
+}
+
+/* ---- Math / domain cell ---- */
+.col-domain,
+.col-condition {
+  white-space: normal;
+  word-break: break-word;
+}
+.col-atom,
+.col-meaning,
+.col-monotonicity {
+  white-space: normal;
+  word-break: break-word;
+}
+.math-cell {
+  font-size: inherit;
+}
+.math-cell :deep(mjx-container) {
+  font-size: 1em;
+}
+
+/* ---- Curvature cell ---- */
+.curvature-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  white-space: nowrap;
+}
+
+.curvature-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+/* Dark mode: brighten SVG stroke */
+:root.dark .curvature-path {
+  filter: brightness(1.3);
+}
+
+/* ---- Monotonicity cell ---- */
+.mono-cell {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.15rem;
+}
+
+.mono-part {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  white-space: nowrap;
+  font-size: inherit;
+}
+
+.mono-sep {
+  color: var(--vp-c-text-3);
+}
+
+.mono-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+:root.dark .mono-path {
+  filter: brightness(1.3);
+}
+
+/* Dark mode: dropdown shadow */
+:root.dark .header-filter-dropdown {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+/* ---- No results ---- */
+.no-results {
+  text-align: center;
+  color: var(--vp-c-text-3);
+  padding: 2rem 0.75rem !important;
+  font-style: italic;
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 768px) {
+  .atom-table-filters {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .atom-search {
+    max-width: 100%;
+    flex: 1 1 auto;
+  }
+  .atom-table {
+    font-size: 0.75rem;
+  }
+}
+</style>

--- a/docs/src/.vitepress/theme/index.ts
+++ b/docs/src/.vitepress/theme/index.ts
@@ -4,6 +4,7 @@ import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
 
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
+import AtomTable from './components/AtomTable.vue'
 import './style.css'
 
 export default {
@@ -15,5 +16,6 @@ export default {
   },
   enhanceApp({ app, router, siteData }) {
     enhanceAppWithTabs(app)
+    app.component('AtomTable', AtomTable)
   }
 } satisfies Theme

--- a/docs/src/atoms.md
+++ b/docs/src/atoms.md
@@ -2,7 +2,7 @@
 
 This page is intended to be a reference for the atoms that are currently implemented in this package with their respective properties. As much as possible atoms are created with functions from base, standard libraries and popular packages, but we also inherit a few functions from the CVX family of packages such as `quad_form`, `quad_over_lin` etc. and also introduce some new functions in this package. Description of all such special functions implemented in this package is available in the [Special functions](@ref) section of the documentation.
 
-Use the **search box** to filter by name, or the **dropdown menus** to filter by curvature, sign, or monotonicity. Click any **column header** to sort.
+Use the **dropdown menus** to filter by curvature, sign, or monotonicity. Click any **column header** to sort. Atom names link to their documentation — external links (marked with ↗) open in a new tab.
 
 ## DCP Atoms
 

--- a/docs/src/atoms.md
+++ b/docs/src/atoms.md
@@ -2,110 +2,32 @@
 
 This page is intended to be a reference for the atoms that are currently implemented in this package with their respective properties. As much as possible atoms are created with functions from base, standard libraries and popular packages, but we also inherit a few functions from the CVX family of packages such as `quad_form`, `quad_over_lin` etc. and also introduce some new functions in this package. Description of all such special functions implemented in this package is available in the [Special functions](@ref) section of the documentation.
 
+Use the **search box** to filter by name, or the **dropdown menus** to filter by curvature, sign, or monotonicity. Click any **column header** to sort.
+
 ## DCP Atoms
 
-| Atom                      | Domain                                                                         | Sign      | Curvature | Monotonicity                                |
-|:------------------------- |:------------------------------------------------------------------------------ |:--------- |:--------- |:------------------------------------------- |
-| dot                       | (array_domain(ℝ), array_domain(ℝ))                                             | AnySign   | Affine    | Increasing                                  |
-| dotsort                   | (array_domain(ℝ, 1), array_domain(ℝ, 1))                                       | AnySign   | Convex    | (AnyMono, increasing_if_positive ∘ minimum) |
-| StatsBase.geomean         | array_domain(HalfLine{Real,:open}(), 1)                                        | Positive  | Concave   | Increasing                                  |
-| StatsBase.harmmean        | array_domain(HalfLine{Real,:open}(), 1)                                        | Positive  | Concave   | Increasing                                  |
-| invprod                   | array_domain(HalfLine{Real,:open}())                                           | Positive  | Convex    | Decreasing                                  |
-| eigmax                    | symmetric_domain()                                                             | AnySign   | Convex    | AnyMono                                     |
-| eigmin                    | symmetric_domain()                                                             | AnySign   | Concave   | AnyMono                                     |
-| eigsummax                 | (array_domain(ℝ, 2), ℝ)                                                        | AnySign   | Convex    | AnyMono                                     |
-| eigsummin                 | (array_domain(ℝ, 2), ℝ)                                                        | AnySign   | Concave   | AnyMono                                     |
-| logdet                    | semidefinite_domain()                                                          | AnySign   | Concave   | AnyMono                                     |
-| LogExpFunctions.logsumexp | array_domain(ℝ, 2)                                                             | AnySign   | Convex    | Increasing                                  |
-| matrix_frac               | (array_domain(ℝ, 1), definite_domain())                                        | AnySign   | Convex    | AnyMono                                     |
-| maximum                   | array_domain(ℝ)                                                                | AnySign   | Convex    | Increasing                                  |
-| minimum                   | array_domain(ℝ)                                                                | AnySign   | Concave   | Increasing                                  |
-| norm                      | (array_domain(ℝ), Interval{:closed, :open}(1, Inf))                            | Positive  | Convex    | increasing_if_positive                      |
-| norm                      | (array_domain(ℝ), Interval{:closed, :open}(0, 1))                              | Positive  | Convex    | increasing_if_positive                      |
-| perspective(f, x, s)      | (function_domain(), ℝ, Positive)                                               | Same as f | Same as f | AnyMono                                     |
-| quad_form                 | (array_domain(ℝ, 1), semidefinite_domain())                                    | Positive  | Convex    | (increasing_if_positive, Increasing)        |
-| quad_over_lin             | (array_domain(ℝ), HalfLine{Real,:open}())                                      | Positive  | Convex    | (increasing_if_positive, Decreasing)        |
-| quad_over_lin             | (ℝ, HalfLine{Real,:open}())                                                    | Positive  | Convex    | (increasing_if_positive, Decreasing)        |
-| sum                       | array_domain(ℝ, 2)                                                             | AnySign   | Affine    | Increasing                                  |
-| sum_largest               | (array_domain(ℝ, 2), ℤ)                                                        | AnySign   | Convex    | Increasing                                  |
-| sum_smallest              | (array_domain(ℝ, 2), ℤ)                                                        | AnySign   | Concave   | Increasing                                  |
-| tr                        | array_domain(ℝ, 2)                                                             | AnySign   | Affine    | Increasing                                  |
-| trinv                     | definite_domain()                                                              | Positive  | Convex    | AnyMono                                     |
-| tv                        | array_domain(ℝ, 1)                                                             | Positive  | Convex    | AnyMono                                     |
-| tv                        | array_domain(array_domain(ℝ, 2), 1)                                            | Positive  | Convex    | AnyMono                                     |
-| abs                       | ℂ                                                                              | Positive  | Convex    | increasing_if_positive                      |
-| conj                      | ℂ                                                                              | AnySign   | Affine    | AnyMono                                     |
-| exp                       | ℝ                                                                              | Positive  | Convex    | Increasing                                  |
-| xlogx                     | ℝ                                                                              | AnySign   | Convex    | AnyMono                                     |
-| huber                     | (ℝ, HalfLine())                                                                | Positive  | Convex    | increasing_if_positive                      |
-| imag                      | ℂ                                                                              | AnySign   | Affine    | AnyMono                                     |
-| inv                       | HalfLine{Real,:open}()                                                         | Positive  | Convex    | Decreasing                                  |
-| log                       | HalfLine{Real,:open}()                                                         | AnySign   | Concave   | Increasing                                  |
-| log                       | array_domain(ℝ, 2)                                                             | Positive  | Concave   | Increasing                                  |
-| inv                       | semidefinite_domain()                                                          | AnySign   | Convex    | Decreasing                                  |
-| sqrt                      | semidefinite_domain()                                                          | Positive  | Concave   | Increasing                                  |
-| kldivergence              | (array_domain(HalfLine{Real,:open}, 1), array_domain(HalfLine{Real,:open}, 1)) | Positive  | Convex    | AnyMono                                     |
-| lognormcdf                | ℝ                                                                              | Negative  | Concave   | Increasing                                  |
-| log1p                     | Interval{:open,:open}(-1, Inf)                                                 | Negative  | Concave   | Increasing                                  |
-| logistic                  | ℝ                                                                              | Positive  | Convex    | Increasing                                  |
-| max                       | (ℝ, ℝ)                                                                         | AnySign   | Convex    | Increasing                                  |
-| min                       | (ℝ, ℝ)                                                                         | AnySign   | Concave   | Increasing                                  |
-| ^(x, i)                   | See below                                                                      | See below | See below | See below                                   |
-| real                      | ℂ                                                                              | AnySign   | Affine    | Increasing                                  |
-| rel_entr                  | (HalfLine{Real,:open}(), HalfLine{Real,:open}())                               | AnySign   | Convex    | (AnyMono, Decreasing)                       |
-| sqrt                      | HalfLine()                                                                     | Positive  | Concave   | Increasing                                  |
-| xexpx                     | HalfLine                                                                       | Positive  | Convex    | Increasing                                  |
-| conv                      | (array_domain(ℝ, 1), array_domain(ℝ, 1))                                       | AnySign   | Affine    | AnyMono                                     |
-| cumsum                    | array_domain(ℝ)                                                                | AnySign   | Affine    | Increasing                                  |
-| diagm                     | array_domain(ℝ, 1)                                                             | AnySign   | Affine    | Increasing                                  |
-| diag                      | array_domain(ℝ, 2)                                                             | AnySign   | Affine    | Increasing                                  |
-| diff                      | array_domain(ℝ)                                                                | AnySign   | Affine    | Increasing                                  |
-| kron                      | (array_domain(ℝ, 2), array_domain(ℝ, 2))                                       | AnySign   | Affine    | Increasing                                  |
+```@raw html
+<AtomTable src="dcp" />
+```
 
-### Special Cases for ^(x, i)
+### Special Cases for `^(x, i)`
 
-| Condition on i    | Domain                      | Sign     | Curvature | Monotonicity           |
-|:----------------- |:--------------------------- |:-------- |:--------- |:---------------------- |
-| i = 1             | ℝ                           | AnySign  | Affine    | Increasing             |
-| i is even integer | ℝ                           | Positive | Convex    | increasing_if_positive |
-| i is odd integer  | HalfLine()                  | Positive | Convex    | Increasing             |
-| i ≥ 1             | HalfLine()                  | Positive | Convex    | Increasing             |
-| 0 < i < 1         | HalfLine()                  | Positive | Concave   | Increasing             |
-| i < 0             | HalfLine{Float64,:closed}() | Positive | Convex    | Increasing             |
+```@raw html
+<AtomTable src="dcp-power" />
+```
 
-## DGCP Atoms (Symmetric Positive Definite)
+## DGCP Atoms (SPD)
 
-| Atom                       | Sign     | Geodesic Curvature | Monotonicity |
-|:-------------------------- |:-------- |:------------------ |:------------ |
-| LinearAlgebra.logdet       | Positive | GLinear            | GIncreasing  |
-| conjugation                | Positive | GConvex            | GIncreasing  |
-| LinearAlgebra.tr           | Positive | GConvex            | GIncreasing  |
-| sum                        | Positive | GConvex            | GIncreasing  |
-| adjoint                    | Positive | GLinear            | GIncreasing  |
-| scalar_mat                 | Positive | GConvex            | GIncreasing  |
-| LinearAlgebra.diag         | Positive | GConvex            | GIncreasing  |
-| sdivergence                | Positive | GConvex            | GIncreasing  |
-| Manifolds.distance         | Positive | GConvex            | GAnyMono     |
-| SymbolicAnalysis.quad_form | Positive | GConvex            | GIncreasing  |
-| LinearAlgebra.eigmax       | Positive | GConvex            | GIncreasing  |
-| log_quad_form              | Positive | GConvex            | GIncreasing  |
-| inv                        | Positive | GConvex            | GDecreasing  |
-| diag                       | Positive | GConvex            | GIncreasing  |
-| eigsummax                  | Positive | GConvex            | GIncreasing  |
-| schatten_norm              | Positive | GConvex            | GIncreasing  |
-| sum_log_eigmax             | Positive | GConvex            | GIncreasing  |
-| affine_map                 | Positive | GConvex            | GIncreasing  |
-| hadamard_product           | Positive | GConvex            | GIncreasing  |
+```@raw html
+<AtomTable src="dgcp-spd" />
+```
 
-## DGCP Atoms (Lorentz Model)
+## DGCP Atoms (Lorentz)
 
-| Atom                          | Sign     | Geodesic Curvature | Monotonicity |
-|:----------------------------- |:-------- |:------------------ |:------------ |
-| lorentz_distance              | Positive | GConvex            | GAnyMono     |
-| lorentz_log_barrier           | Positive | GConvex            | GIncreasing  |
-| lorentz_homogeneous_quadratic | Positive | GConvex            | GAnyMono     |
-| lorentz_homogeneous_diagonal  | Positive | GConvex            | GAnyMono     |
-| lorentz_least_squares         | Positive | GConvex            | GAnyMono     |
-| lorentz_transform             | -        | -                  | -            |
+```@raw html
+<AtomTable src="dgcp-lorentz" />
+```
 
-Note: `lorentz_transform` does not have specific geodesic curvature properties by itself, but it preserves geodesic convexity when applied to geodesically convex functions.
+!!! note
+    `lorentz_transform` does not have specific geodesic curvature properties by itself, 
+    but it preserves geodesic convexity when applied to geodesically convex functions.

--- a/docs/src/data/dcp_atoms.json
+++ b/docs/src/data/dcp_atoms.json
@@ -144,7 +144,7 @@
     "monotonicity": "(Incr. if pos., Increasing)"
   },
   {
-    "atom": "quad_over_lin (array)",
+    "atom": "quad_over_lin",
     "meaning": "\\|x\\|_2^2 / y",
     "domain": "\\mathbb{R}^n \\times \\mathbb{R}_{++}",
     "sign": "Positive",
@@ -152,7 +152,7 @@
     "monotonicity": "(Incr. if pos., Decreasing)"
   },
   {
-    "atom": "quad_over_lin (scalar)",
+    "atom": "quad_over_lin",
     "meaning": "x^2 / y",
     "domain": "\\mathbb{R} \\times \\mathbb{R}_{++}",
     "sign": "Positive",
@@ -249,7 +249,7 @@
   },
   {
     "atom": "huber",
-    "meaning": "\\begin{cases} x^2 & |x|\\le M \\\\ 2M|x|-M^2 & \\text{else} \\end{cases}",
+    "meaning": "\\begin{cases} x^2 \\quad |x|\\le M & \\\\ 2M|x|-M^2 & \\text{else} \\end{cases}",
     "domain": "\\mathbb{R} \\times \\mathbb{R}_+",
     "sign": "Positive",
     "curvature": "Convex",

--- a/docs/src/data/dcp_atoms.json
+++ b/docs/src/data/dcp_atoms.json
@@ -1,0 +1,434 @@
+[
+  {
+    "atom": "dot",
+    "meaning": "x^\\top y",
+    "domain": "\\mathbb{R}^n \\times \\mathbb{R}^n",
+    "sign": "AnySign",
+    "curvature": "Affine",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "dotsort",
+    "meaning": "\\operatorname{sort}(x)^\\top \\operatorname{sort}(y)",
+    "domain": "\\mathbb{R}^n \\times \\mathbb{R}^n",
+    "sign": "AnySign",
+    "curvature": "Convex",
+    "monotonicity": "(Any, Incr. if pos. ∘ minimum)"
+  },
+  {
+    "atom": "geomean",
+    "meaning": "\\left(\\prod_{i=1}^n x_i\\right)^{1/n}",
+    "domain": "\\mathbb{R}_{++}^n",
+    "sign": "Positive",
+    "curvature": "Concave",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "harmmean",
+    "meaning": "\\frac{n}{\\sum_{i=1}^n x_i^{-1}}",
+    "domain": "\\mathbb{R}_{++}^n",
+    "sign": "Positive",
+    "curvature": "Concave",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "invprod",
+    "meaning": "\\frac{1}{\\prod_{i} x_i}",
+    "domain": "\\mathbb{R}_{++}^n",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Decreasing"
+  },
+  {
+    "atom": "eigmax",
+    "meaning": "\\lambda_{\\max}(X)",
+    "domain": "\\mathbb{S}^n",
+    "sign": "AnySign",
+    "curvature": "Convex",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "eigmin",
+    "meaning": "\\lambda_{\\min}(X)",
+    "domain": "\\mathbb{S}^n",
+    "sign": "AnySign",
+    "curvature": "Concave",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "eigsummax",
+    "meaning": "\\sum_{i=1}^{k} \\lambda_i^{\\downarrow}(X)",
+    "domain": "\\mathbb{R}^{m \\times n} \\times \\mathbb{R}",
+    "sign": "AnySign",
+    "curvature": "Convex",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "eigsummin",
+    "meaning": "\\sum_{i=1}^{k} \\lambda_i^{\\uparrow}(X)",
+    "domain": "\\mathbb{R}^{m \\times n} \\times \\mathbb{R}",
+    "sign": "AnySign",
+    "curvature": "Concave",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "logdet",
+    "meaning": "\\log \\det(X)",
+    "domain": "\\mathbb{S}_+^n",
+    "sign": "AnySign",
+    "curvature": "Concave",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "logsumexp",
+    "meaning": "\\log \\sum_{i} e^{x_i}",
+    "domain": "\\mathbb{R}^{m \\times n}",
+    "sign": "AnySign",
+    "curvature": "Convex",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "matrix_frac",
+    "meaning": "x^\\top P^{-1} x",
+    "domain": "\\mathbb{R}^n \\times \\mathbb{S}_{++}^n",
+    "sign": "AnySign",
+    "curvature": "Convex",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "maximum",
+    "meaning": "\\max_i\\, x_i",
+    "domain": "\\mathbb{R}^n",
+    "sign": "AnySign",
+    "curvature": "Convex",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "minimum",
+    "meaning": "\\min_i\\, x_i",
+    "domain": "\\mathbb{R}^n",
+    "sign": "AnySign",
+    "curvature": "Concave",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "norm (p ≥ 1)",
+    "meaning": "\\|x\\|_p",
+    "domain": "\\mathbb{R}^n \\times [1, \\infty)",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Incr. if pos."
+  },
+  {
+    "atom": "norm (0 < p < 1)",
+    "meaning": "\\|x\\|_p",
+    "domain": "\\mathbb{R}^n \\times [0, 1)",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Incr. if pos."
+  },
+  {
+    "atom": "perspective(f, x, s)",
+    "meaning": "s \\cdot f(x/s)",
+    "domain": "f \\times \\mathbb{R} \\times \\mathbb{R}_+",
+    "sign": "Same as f",
+    "curvature": "Same as f",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "quad_form",
+    "meaning": "x^\\top P x",
+    "domain": "\\mathbb{R}^n \\times \\mathbb{S}_+^n",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "(Incr. if pos., Increasing)"
+  },
+  {
+    "atom": "quad_over_lin (array)",
+    "meaning": "\\|x\\|_2^2 / y",
+    "domain": "\\mathbb{R}^n \\times \\mathbb{R}_{++}",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "(Incr. if pos., Decreasing)"
+  },
+  {
+    "atom": "quad_over_lin (scalar)",
+    "meaning": "x^2 / y",
+    "domain": "\\mathbb{R} \\times \\mathbb{R}_{++}",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "(Incr. if pos., Decreasing)"
+  },
+  {
+    "atom": "sum",
+    "meaning": "\\sum_{ij} X_{ij}",
+    "domain": "\\mathbb{R}^{m \\times n}",
+    "sign": "AnySign",
+    "curvature": "Affine",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "sum_largest",
+    "meaning": "\\sum_{i=1}^{k} x_i^{\\downarrow}",
+    "domain": "\\mathbb{R}^{m \\times n} \\times \\mathbb{Z}",
+    "sign": "AnySign",
+    "curvature": "Convex",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "sum_smallest",
+    "meaning": "\\sum_{i=1}^{k} x_i^{\\uparrow}",
+    "domain": "\\mathbb{R}^{m \\times n} \\times \\mathbb{Z}",
+    "sign": "AnySign",
+    "curvature": "Concave",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "tr",
+    "meaning": "\\operatorname{tr}(X)",
+    "domain": "\\mathbb{R}^{m \\times n}",
+    "sign": "AnySign",
+    "curvature": "Affine",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "trinv",
+    "meaning": "\\operatorname{tr}(X^{-1})",
+    "domain": "\\mathbb{S}_{++}^n",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "tv (vector)",
+    "meaning": "\\sum_i |x_{i+1} - x_i|",
+    "domain": "\\mathbb{R}^n",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "tv (matrix)",
+    "meaning": "\\sum_{i,j} \\|x_{i+1,j} - x_{i,j}\\|_2",
+    "domain": "(\\mathbb{R}^{m \\times n})^k",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "abs",
+    "meaning": "|x|",
+    "domain": "\\mathbb{C}",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Incr. if pos."
+  },
+  {
+    "atom": "conj",
+    "meaning": "\\bar{x}",
+    "domain": "\\mathbb{C}",
+    "sign": "AnySign",
+    "curvature": "Affine",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "exp",
+    "meaning": "e^x",
+    "domain": "\\mathbb{R}",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "xlogx",
+    "meaning": "x \\log x",
+    "domain": "\\mathbb{R}",
+    "sign": "AnySign",
+    "curvature": "Convex",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "huber",
+    "meaning": "\\begin{cases} x^2 & |x|\\le M \\\\ 2M|x|-M^2 & \\text{else} \\end{cases}",
+    "domain": "\\mathbb{R} \\times \\mathbb{R}_+",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Incr. if pos."
+  },
+  {
+    "atom": "imag",
+    "meaning": "\\operatorname{Im}(x)",
+    "domain": "\\mathbb{C}",
+    "sign": "AnySign",
+    "curvature": "Affine",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "inv (scalar)",
+    "meaning": "1/x",
+    "domain": "\\mathbb{R}_{++}",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Decreasing"
+  },
+  {
+    "atom": "log (scalar)",
+    "meaning": "\\log x",
+    "domain": "\\mathbb{R}_{++}",
+    "sign": "AnySign",
+    "curvature": "Concave",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "log (matrix)",
+    "meaning": "\\log(X)",
+    "domain": "\\mathbb{R}^{m \\times n}",
+    "sign": "Positive",
+    "curvature": "Concave",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "inv (matrix)",
+    "meaning": "X^{-1}",
+    "domain": "\\mathbb{S}_+^n",
+    "sign": "AnySign",
+    "curvature": "Convex",
+    "monotonicity": "Decreasing"
+  },
+  {
+    "atom": "sqrt (matrix)",
+    "meaning": "X^{1/2}",
+    "domain": "\\mathbb{S}_+^n",
+    "sign": "Positive",
+    "curvature": "Concave",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "kldivergence",
+    "meaning": "\\sum_i x_i \\log\\!\\left(\\frac{x_i}{y_i}\\right)",
+    "domain": "\\mathbb{R}_{++}^n \\times \\mathbb{R}_{++}^n",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "lognormcdf",
+    "meaning": "\\log \\Phi(x)",
+    "domain": "\\mathbb{R}",
+    "sign": "Negative",
+    "curvature": "Concave",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "log1p",
+    "meaning": "\\log(1 + x)",
+    "domain": "(-1, \\infty)",
+    "sign": "Negative",
+    "curvature": "Concave",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "logistic",
+    "meaning": "\\log(1 + e^x)",
+    "domain": "\\mathbb{R}",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "max",
+    "meaning": "\\max(x, y)",
+    "domain": "\\mathbb{R} \\times \\mathbb{R}",
+    "sign": "AnySign",
+    "curvature": "Convex",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "min",
+    "meaning": "\\min(x, y)",
+    "domain": "\\mathbb{R} \\times \\mathbb{R}",
+    "sign": "AnySign",
+    "curvature": "Concave",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "real",
+    "meaning": "\\operatorname{Re}(x)",
+    "domain": "\\mathbb{C}",
+    "sign": "AnySign",
+    "curvature": "Affine",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "rel_entr",
+    "meaning": "x \\log(x / y)",
+    "domain": "\\mathbb{R}_{++} \\times \\mathbb{R}_{++}",
+    "sign": "AnySign",
+    "curvature": "Convex",
+    "monotonicity": "(Any, Decreasing)"
+  },
+  {
+    "atom": "sqrt (scalar)",
+    "meaning": "\\sqrt{x}",
+    "domain": "\\mathbb{R}_+",
+    "sign": "Positive",
+    "curvature": "Concave",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "xexpx",
+    "meaning": "x e^x",
+    "domain": "\\mathbb{R}_+",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "conv",
+    "meaning": "x * y",
+    "domain": "\\mathbb{R}^n \\times \\mathbb{R}^n",
+    "sign": "AnySign",
+    "curvature": "Affine",
+    "monotonicity": "Any"
+  },
+  {
+    "atom": "cumsum",
+    "meaning": "\\left[\\sum_{j=1}^{i} x_j\\right]_i",
+    "domain": "\\mathbb{R}^n",
+    "sign": "AnySign",
+    "curvature": "Affine",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "diagm",
+    "meaning": "\\left[\\begin{smallmatrix}x_1 & & \\\\ & \\ddots & \\\\ & & x_n\\end{smallmatrix}\\right]",
+    "domain": "\\mathbb{R}^n",
+    "sign": "AnySign",
+    "curvature": "Affine",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "diag",
+    "meaning": "[X_{11}, \\ldots, X_{nn}]",
+    "domain": "\\mathbb{R}^{m \\times n}",
+    "sign": "AnySign",
+    "curvature": "Affine",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "diff",
+    "meaning": "[x_{i+1} - x_i]_i",
+    "domain": "\\mathbb{R}^n",
+    "sign": "AnySign",
+    "curvature": "Affine",
+    "monotonicity": "Increasing"
+  },
+  {
+    "atom": "kron",
+    "meaning": "X \\otimes Y",
+    "domain": "\\mathbb{R}^{m \\times n} \\times \\mathbb{R}^{m \\times n}",
+    "sign": "AnySign",
+    "curvature": "Affine",
+    "monotonicity": "Increasing"
+  }
+]

--- a/docs/src/data/dcp_atoms.json
+++ b/docs/src/data/dcp_atoms.json
@@ -5,7 +5,8 @@
     "domain": "\\mathbb{R}^n \\times \\mathbb{R}^n",
     "sign": "AnySign",
     "curvature": "Affine",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.dot"
   },
   {
     "atom": "dotsort",
@@ -21,7 +22,8 @@
     "domain": "\\mathbb{R}_{++}^n",
     "sign": "Positive",
     "curvature": "Concave",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://juliastats.org/StatsBase.jl/stable/scalarstats/#StatsBase.geomean"
   },
   {
     "atom": "harmmean",
@@ -29,7 +31,8 @@
     "domain": "\\mathbb{R}_{++}^n",
     "sign": "Positive",
     "curvature": "Concave",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://juliastats.org/StatsBase.jl/stable/scalarstats/#StatsBase.harmmean"
   },
   {
     "atom": "invprod",
@@ -45,7 +48,8 @@
     "domain": "\\mathbb{S}^n",
     "sign": "AnySign",
     "curvature": "Convex",
-    "monotonicity": "Any"
+    "monotonicity": "Any",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.eigmax"
   },
   {
     "atom": "eigmin",
@@ -53,7 +57,8 @@
     "domain": "\\mathbb{S}^n",
     "sign": "AnySign",
     "curvature": "Concave",
-    "monotonicity": "Any"
+    "monotonicity": "Any",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.eigmin"
   },
   {
     "atom": "eigsummax",
@@ -77,7 +82,8 @@
     "domain": "\\mathbb{S}_+^n",
     "sign": "AnySign",
     "curvature": "Concave",
-    "monotonicity": "Any"
+    "monotonicity": "Any",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.logdet"
   },
   {
     "atom": "logsumexp",
@@ -85,7 +91,8 @@
     "domain": "\\mathbb{R}^{m \\times n}",
     "sign": "AnySign",
     "curvature": "Convex",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://juliastats.org/LogExpFunctions.jl/stable/api/#LogExpFunctions.logsumexp"
   },
   {
     "atom": "matrix_frac",
@@ -101,7 +108,8 @@
     "domain": "\\mathbb{R}^n",
     "sign": "AnySign",
     "curvature": "Convex",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/collections/#Base.maximum"
   },
   {
     "atom": "minimum",
@@ -109,7 +117,8 @@
     "domain": "\\mathbb{R}^n",
     "sign": "AnySign",
     "curvature": "Concave",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/collections/#Base.minimum"
   },
   {
     "atom": "norm (p ≥ 1)",
@@ -117,7 +126,8 @@
     "domain": "\\mathbb{R}^n \\times [1, \\infty)",
     "sign": "Positive",
     "curvature": "Convex",
-    "monotonicity": "Incr. if pos."
+    "monotonicity": "Incr. if pos.",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.norm"
   },
   {
     "atom": "norm (0 < p < 1)",
@@ -125,7 +135,8 @@
     "domain": "\\mathbb{R}^n \\times [0, 1)",
     "sign": "Positive",
     "curvature": "Convex",
-    "monotonicity": "Incr. if pos."
+    "monotonicity": "Incr. if pos.",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.norm"
   },
   {
     "atom": "perspective(f, x, s)",
@@ -165,7 +176,8 @@
     "domain": "\\mathbb{R}^{m \\times n}",
     "sign": "AnySign",
     "curvature": "Affine",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/collections/#Base.sum"
   },
   {
     "atom": "sum_largest",
@@ -189,7 +201,8 @@
     "domain": "\\mathbb{R}^{m \\times n}",
     "sign": "AnySign",
     "curvature": "Affine",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.tr"
   },
   {
     "atom": "trinv",
@@ -221,7 +234,8 @@
     "domain": "\\mathbb{C}",
     "sign": "Positive",
     "curvature": "Convex",
-    "monotonicity": "Incr. if pos."
+    "monotonicity": "Incr. if pos.",
+    "docUrl": "https://docs.julialang.org/en/v1/base/math/#Base.abs"
   },
   {
     "atom": "conj",
@@ -229,7 +243,8 @@
     "domain": "\\mathbb{C}",
     "sign": "AnySign",
     "curvature": "Affine",
-    "monotonicity": "Any"
+    "monotonicity": "Any",
+    "docUrl": "https://docs.julialang.org/en/v1/base/math/#Base.conj"
   },
   {
     "atom": "exp",
@@ -237,7 +252,8 @@
     "domain": "\\mathbb{R}",
     "sign": "Positive",
     "curvature": "Convex",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/math/#Base.exp-Tuple{Float64}"
   },
   {
     "atom": "xlogx",
@@ -245,7 +261,8 @@
     "domain": "\\mathbb{R}",
     "sign": "AnySign",
     "curvature": "Convex",
-    "monotonicity": "Any"
+    "monotonicity": "Any",
+    "docUrl": "https://juliastats.org/LogExpFunctions.jl/stable/api/#LogExpFunctions.xlogx"
   },
   {
     "atom": "huber",
@@ -261,7 +278,8 @@
     "domain": "\\mathbb{C}",
     "sign": "AnySign",
     "curvature": "Affine",
-    "monotonicity": "Any"
+    "monotonicity": "Any",
+    "docUrl": "https://docs.julialang.org/en/v1/base/math/#Base.imag"
   },
   {
     "atom": "inv (scalar)",
@@ -269,7 +287,8 @@
     "domain": "\\mathbb{R}_{++}",
     "sign": "Positive",
     "curvature": "Convex",
-    "monotonicity": "Decreasing"
+    "monotonicity": "Decreasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/math/#Base.inv-Tuple{Number}"
   },
   {
     "atom": "log (scalar)",
@@ -277,7 +296,8 @@
     "domain": "\\mathbb{R}_{++}",
     "sign": "AnySign",
     "curvature": "Concave",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/math/#Base.log-Tuple{Number}"
   },
   {
     "atom": "log (matrix)",
@@ -285,7 +305,8 @@
     "domain": "\\mathbb{R}^{m \\times n}",
     "sign": "Positive",
     "curvature": "Concave",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/math/#Base.log-Tuple{Number}"
   },
   {
     "atom": "inv (matrix)",
@@ -293,7 +314,8 @@
     "domain": "\\mathbb{S}_+^n",
     "sign": "AnySign",
     "curvature": "Convex",
-    "monotonicity": "Decreasing"
+    "monotonicity": "Decreasing",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.inv-Tuple{AbstractMatrix}"
   },
   {
     "atom": "sqrt (matrix)",
@@ -301,7 +323,8 @@
     "domain": "\\mathbb{S}_+^n",
     "sign": "Positive",
     "curvature": "Concave",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.sqrt-Tuple{AbstractMatrix}"
   },
   {
     "atom": "kldivergence",
@@ -309,7 +332,8 @@
     "domain": "\\mathbb{R}_{++}^n \\times \\mathbb{R}_{++}^n",
     "sign": "Positive",
     "curvature": "Convex",
-    "monotonicity": "Any"
+    "monotonicity": "Any",
+    "docUrl": "https://juliastats.org/StatsBase.jl/stable/signalcorr/#StatsBase.kldivergence"
   },
   {
     "atom": "lognormcdf",
@@ -325,7 +349,8 @@
     "domain": "(-1, \\infty)",
     "sign": "Negative",
     "curvature": "Concave",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/math/#Base.log1p"
   },
   {
     "atom": "logistic",
@@ -333,7 +358,8 @@
     "domain": "\\mathbb{R}",
     "sign": "Positive",
     "curvature": "Convex",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://juliastats.org/LogExpFunctions.jl/stable/api/#LogExpFunctions.logistic"
   },
   {
     "atom": "max",
@@ -341,7 +367,8 @@
     "domain": "\\mathbb{R} \\times \\mathbb{R}",
     "sign": "AnySign",
     "curvature": "Convex",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/math/#Base.max"
   },
   {
     "atom": "min",
@@ -349,7 +376,8 @@
     "domain": "\\mathbb{R} \\times \\mathbb{R}",
     "sign": "AnySign",
     "curvature": "Concave",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/math/#Base.min"
   },
   {
     "atom": "real",
@@ -357,7 +385,8 @@
     "domain": "\\mathbb{C}",
     "sign": "AnySign",
     "curvature": "Affine",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/math/#Base.real"
   },
   {
     "atom": "rel_entr",
@@ -373,7 +402,8 @@
     "domain": "\\mathbb{R}_+",
     "sign": "Positive",
     "curvature": "Concave",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/math/#Base.sqrt-Tuple{Real}"
   },
   {
     "atom": "xexpx",
@@ -381,7 +411,8 @@
     "domain": "\\mathbb{R}_+",
     "sign": "Positive",
     "curvature": "Convex",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://juliastats.org/LogExpFunctions.jl/stable/api/#LogExpFunctions.xexpx"
   },
   {
     "atom": "conv",
@@ -389,7 +420,8 @@
     "domain": "\\mathbb{R}^n \\times \\mathbb{R}^n",
     "sign": "AnySign",
     "curvature": "Affine",
-    "monotonicity": "Any"
+    "monotonicity": "Any",
+    "docUrl": "https://docs.juliadsp.org/stable/convolutions/#DSP.conv"
   },
   {
     "atom": "cumsum",
@@ -397,7 +429,8 @@
     "domain": "\\mathbb{R}^n",
     "sign": "AnySign",
     "curvature": "Affine",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/arrays/#Base.cumsum"
   },
   {
     "atom": "diagm",
@@ -405,7 +438,8 @@
     "domain": "\\mathbb{R}^n",
     "sign": "AnySign",
     "curvature": "Affine",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.diagm"
   },
   {
     "atom": "diag",
@@ -413,7 +447,8 @@
     "domain": "\\mathbb{R}^{m \\times n}",
     "sign": "AnySign",
     "curvature": "Affine",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.diag"
   },
   {
     "atom": "diff",
@@ -421,7 +456,8 @@
     "domain": "\\mathbb{R}^n",
     "sign": "AnySign",
     "curvature": "Affine",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/arrays/#Base.diff"
   },
   {
     "atom": "kron",
@@ -429,6 +465,7 @@
     "domain": "\\mathbb{R}^{m \\times n} \\times \\mathbb{R}^{m \\times n}",
     "sign": "AnySign",
     "curvature": "Affine",
-    "monotonicity": "Increasing"
+    "monotonicity": "Increasing",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.kron"
   }
 ]

--- a/docs/src/data/dcp_power_atoms.json
+++ b/docs/src/data/dcp_power_atoms.json
@@ -1,0 +1,50 @@
+[
+  {
+    "condition": "i = 1",
+    "meaning": "x",
+    "domain": "\\mathbb{R}",
+    "sign": "AnySign",
+    "curvature": "Affine",
+    "monotonicity": "Increasing"
+  },
+  {
+    "condition": "i \\text{ even integer}",
+    "meaning": "x^i",
+    "domain": "\\mathbb{R}",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Incr. if pos."
+  },
+  {
+    "condition": "i \\text{ odd integer}",
+    "meaning": "x^i",
+    "domain": "\\mathbb{R}_+",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Increasing"
+  },
+  {
+    "condition": "i \\geq 1",
+    "meaning": "x^i",
+    "domain": "\\mathbb{R}_+",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Increasing"
+  },
+  {
+    "condition": "0 < i < 1",
+    "meaning": "x^i",
+    "domain": "\\mathbb{R}_+",
+    "sign": "Positive",
+    "curvature": "Concave",
+    "monotonicity": "Increasing"
+  },
+  {
+    "condition": "i < 0",
+    "meaning": "x^i",
+    "domain": "\\mathbb{R}_+",
+    "sign": "Positive",
+    "curvature": "Convex",
+    "monotonicity": "Increasing"
+  }
+]

--- a/docs/src/data/dgcp_lorentz_atoms.json
+++ b/docs/src/data/dgcp_lorentz_atoms.json
@@ -4,7 +4,8 @@
     "meaning": "d_{\\mathbb{H}}(p, q)",
     "sign": "Positive",
     "curvature": "GConvex",
-    "monotonicity": "GAny"
+    "monotonicity": "GAny",
+    "docUrl": "https://juliamanifolds.github.io/Manifolds.jl/stable/interface/#ManifoldsBase.distance-Tuple{AbstractManifold,%20Any,%20Any}"
   },
   {
     "atom": "lorentz_log_barrier",

--- a/docs/src/data/dgcp_lorentz_atoms.json
+++ b/docs/src/data/dgcp_lorentz_atoms.json
@@ -1,0 +1,44 @@
+[
+  {
+    "atom": "lorentz_distance",
+    "meaning": "d_{\\mathbb{H}}(p, q)",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GAny"
+  },
+  {
+    "atom": "lorentz_log_barrier",
+    "meaning": "-\\log(-1 + p_{d+1})",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "lorentz_homogeneous_quadratic",
+    "meaning": "p^\\top A\\, p",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GAny"
+  },
+  {
+    "atom": "lorentz_homogeneous_diagonal",
+    "meaning": "\\sum_i a_i\\, p_i^2",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GAny"
+  },
+  {
+    "atom": "lorentz_least_squares",
+    "meaning": "\\|y - Xp\\|_2^2",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GAny"
+  },
+  {
+    "atom": "lorentz_transform",
+    "meaning": "Op",
+    "sign": "—",
+    "curvature": "—",
+    "monotonicity": "—"
+  }
+]

--- a/docs/src/data/dgcp_spd_atoms.json
+++ b/docs/src/data/dgcp_spd_atoms.json
@@ -1,0 +1,135 @@
+[
+  {
+    "atom": "logdet",
+    "meaning": "\\log \\det(X)",
+    "sign": "Positive",
+    "curvature": "GLinear",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "conjugation",
+    "meaning": "B^\\top X B",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "tr",
+    "meaning": "\\operatorname{tr}(X)",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "sum",
+    "meaning": "\\sum_{ij} X_{ij}",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "adjoint",
+    "meaning": "X^\\top",
+    "sign": "Positive",
+    "curvature": "GLinear",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "scalar_mat",
+    "meaning": "\\operatorname{tr}(X) \\cdot I_k",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "diag",
+    "meaning": "[X_{11}, \\ldots, X_{nn}]",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "sdivergence",
+    "meaning": "\\log\\!\\det\\!\\tfrac{X+Y}{2} - \\tfrac{1}{2}\\log\\!\\det(XY)",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "distance",
+    "meaning": "d_{\\mathbb{S}_{++}^n}(X, Y)",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GAny"
+  },
+  {
+    "atom": "quad_form",
+    "meaning": "x^\\top X x",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "eigmax",
+    "meaning": "\\lambda_{\\max}(X)",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "log_quad_form",
+    "meaning": "\\log(y^\\top X y)",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "inv",
+    "meaning": "X^{-1}",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GDecreasing"
+  },
+  {
+    "atom": "diag",
+    "meaning": "[X_{11}, \\ldots, X_{nn}]",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "eigsummax",
+    "meaning": "\\sum_{i=1}^{k} \\lambda_i^{\\downarrow}(X)",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "schatten_norm",
+    "meaning": "\\left(\\sum_i \\sigma_i^p\\right)^{1/p}",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "sum_log_eigmax",
+    "meaning": "\\sum_{i=1}^{k} f(\\log \\lambda_i^{\\downarrow}(X))",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "affine_map",
+    "meaning": "g(B^\\top X B) + C",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  },
+  {
+    "atom": "hadamard_product",
+    "meaning": "X \\circ Y",
+    "sign": "Positive",
+    "curvature": "GConvex",
+    "monotonicity": "GIncreasing"
+  }
+]

--- a/docs/src/data/dgcp_spd_atoms.json
+++ b/docs/src/data/dgcp_spd_atoms.json
@@ -4,7 +4,8 @@
     "meaning": "\\log \\det(X)",
     "sign": "Positive",
     "curvature": "GLinear",
-    "monotonicity": "GIncreasing"
+    "monotonicity": "GIncreasing",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.logdet"
   },
   {
     "atom": "conjugation",
@@ -18,21 +19,24 @@
     "meaning": "\\operatorname{tr}(X)",
     "sign": "Positive",
     "curvature": "GConvex",
-    "monotonicity": "GIncreasing"
+    "monotonicity": "GIncreasing",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.tr"
   },
   {
     "atom": "sum",
     "meaning": "\\sum_{ij} X_{ij}",
     "sign": "Positive",
     "curvature": "GConvex",
-    "monotonicity": "GIncreasing"
+    "monotonicity": "GIncreasing",
+    "docUrl": "https://docs.julialang.org/en/v1/base/collections/#Base.sum"
   },
   {
     "atom": "adjoint",
     "meaning": "X^\\top",
     "sign": "Positive",
     "curvature": "GLinear",
-    "monotonicity": "GIncreasing"
+    "monotonicity": "GIncreasing",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#Base.adjoint"
   },
   {
     "atom": "scalar_mat",
@@ -46,7 +50,8 @@
     "meaning": "[X_{11}, \\ldots, X_{nn}]",
     "sign": "Positive",
     "curvature": "GConvex",
-    "monotonicity": "GIncreasing"
+    "monotonicity": "GIncreasing",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.diag"
   },
   {
     "atom": "sdivergence",
@@ -60,7 +65,8 @@
     "meaning": "d_{\\mathbb{S}_{++}^n}(X, Y)",
     "sign": "Positive",
     "curvature": "GConvex",
-    "monotonicity": "GAny"
+    "monotonicity": "GAny",
+    "docUrl": "https://juliamanifolds.github.io/Manifolds.jl/stable/interface/#ManifoldsBase.distance-Tuple{AbstractManifold,%20Any,%20Any}"
   },
   {
     "atom": "quad_form",
@@ -74,7 +80,8 @@
     "meaning": "\\lambda_{\\max}(X)",
     "sign": "Positive",
     "curvature": "GConvex",
-    "monotonicity": "GIncreasing"
+    "monotonicity": "GIncreasing",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.eigmax"
   },
   {
     "atom": "log_quad_form",
@@ -88,14 +95,16 @@
     "meaning": "X^{-1}",
     "sign": "Positive",
     "curvature": "GConvex",
-    "monotonicity": "GDecreasing"
+    "monotonicity": "GDecreasing",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.inv-Tuple{AbstractMatrix}"
   },
   {
     "atom": "diag",
     "meaning": "[X_{11}, \\ldots, X_{nn}]",
     "sign": "Positive",
     "curvature": "GConvex",
-    "monotonicity": "GIncreasing"
+    "monotonicity": "GIncreasing",
+    "docUrl": "https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.diag"
   },
   {
     "atom": "eigsummax",


### PR DESCRIPTION
## Summary

This is https://github.com/SciML/SymbolicAnalysis.jl/pull/96 (by @langestefan) plus one fix-up commit, merged with the latest `paperrevisions` so the branch is up to date and the format check is clean. If you'd rather keep authorship flow on #96, the same fixes are open as a fix-up PR into the contributor's branch: https://github.com/langestefan/SymbolicAnalysis.jl/pull/1

The original PR adds a Vue `AtomTable` component rendering the DCP/DGCP atom tables from JSON data (sortable/filterable columns, MathJax-rendered math, doc links). The fix-up commit addresses issues found by building the docs locally:

- **`quad_over_lin` rows had no doc link** — `docLinks` keys didn't match the JSON atom names; renamed the rows to `quad_over_lin (array)` / `(scalar)`.
- **`rel_entr` linked to a nonexistent anchor** — it had no docstring, so `@autodocs` emitted no id. Added a docstring; anchor now resolves.
- **Sign column restored** — JSON had `sign` data and the page text advertises filtering by sign, but no sign column was configured.
- **Dead code removed** — unused `searchQuery`/search logic/CSS (no search input exists in the template), `sortIndicator()`, `darkColor` fields.
- **Nitpicks** — `norm (0 < p < 1)` domain `[0,1)` → `(0,1)`; removed duplicated `diag` row in the SPD table; trailing newlines.

Note: the runic format check on the un-merged `docs` branch failed only on stale `test/experiments/*` files (formatted on `paperrevisions` after the docs branch diverged); this branch is merged with `paperrevisions` tip `d569df3` so the check should pass.

#### Test plan

- [x] `julia --project=docs -e 'include("docs/make.jl")'` — full Documenter → VitePress pipeline builds clean (Julia 1.12, DocumenterVitepress 0.3.6, vitepress 1.6.4)
- [x] All 4 `<AtomTable>` blocks SSR to real `<table>` markup in `atoms.html`; 300 MathJax containers rendered
- [x] Every `./functions.html#...` link used by the tables resolves to a real anchor (verified programmatically — zero missing)
- [x] Sign column renders + is filterable in all four tables
- [x] `git merge-tree` vs `paperrevisions`: no conflicts

🤖 Generated with Devin CLI 3000.10.31 (model: swe-2-max), local session `pitch-trillium` (no published URL; transcript `~/.local/share/devin/cli/transcripts/pitch-trillium.json`)